### PR TITLE
Decrement Depth in DecodeElement()

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -211,6 +211,7 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	// to the previous StartTag event's name
 	p.resetTokenState()
 	p.Event = EndTag
+	p.Depth--
 	p.Name = name
 	p.token = nil
 	return nil


### PR DESCRIPTION
A test case and fix for what I think is a bug where the Depth field is not decremented after unmarshaling an element with `DecodeElement()` (Issue #3)