### PR TITLE
Fix xml:base handling in DecodeElement

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -53,7 +53,7 @@ type XMLPullParser struct {
 	// Document State
 	Spaces      map[string]string
 	SpacesStack []map[string]string
-	BaseStack    urlStack
+	BaseStack   urlStack
 
 	// Token State
 	Depth int
@@ -240,7 +240,17 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	p.Depth--
 	p.Name = name
 	p.token = nil
-	p.popBase()
+
+	// if the token we decoded had an xml:base attribute, we need to pop it
+	// from the stack
+	// Note: this means it is up to the caller of DecodeElement to save the curent xml:base
+	// before calling DecodeElement if it needs to resolve relative URLs in `v`
+	for _, attr := range startToken.Attr {
+		if attr.Name.Space == xmlNSURI && attr.Name.Local == "base" {
+			p.popBase()
+			break
+		}
+	}
 	return nil
 }
 

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -89,7 +89,7 @@ func TestXMLBase(t *testing.T) {
 	crReader := func(charset string, input io.Reader) (io.Reader, error) {
 		return input, nil
 	}
-	r := bytes.NewBufferString(`<root xml:base="https://example.org/"><d2 xml:base="relative">foo</d2><d2>bar</d2></root>`)
+	r := bytes.NewBufferString(`<root xml:base="https://example.org/"><d2 xml:base="relative">foo</d2><d2>bar</d2><d2>baz</d2></root>`)
 	p := xpp.NewXMLPullParser(r, false, crReader)
 
 	type v struct{}
@@ -103,7 +103,7 @@ func TestXMLBase(t *testing.T) {
 	p.NextTag()
 	assert.Equal(t, "d2", p.Name)
 	assert.Equal(t, "https://example.org/relative", p.BaseStack.Top().String())
-	
+
 	resolved, err := p.XmlBaseResolveUrl("test")
 	assert.NoError(t, err)
 	assert.Equal(t, "https://example.org/relative/test", resolved.String())
@@ -114,6 +114,11 @@ func TestXMLBase(t *testing.T) {
 	assert.Equal(t, "d2", p.Name)
 	assert.Equal(t, "https://example.org/", p.BaseStack.Top().String())
 	p.DecodeElement(&v{})
+
+	// ensure xml:base is still set to root element's base
+	p.NextTag()
+	assert.Equal(t, "d2", p.Name)
+	assert.Equal(t, "https://example.org/", p.BaseStack.Top().String())
 }
 
 func toNextStart(t *testing.T, p *xpp.XMLPullParser) {


### PR DESCRIPTION
This PR includes two changes:

- An improved test that fails because the current `DecodeElement` pops the BaseStack even if the current element did not push a base to it
- A fix that only pops the BaseStack when the current element contains an xml:base attribute

For some context see: https://github.com/mmcdole/gofeed/issues/210