### PR TITLE
Fix Skip recursion, NextText O(n^2), and DecodeElement namespace leak

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -163,9 +163,12 @@ func (p *XMLPullParser) NextText() (string, error) {
 		return "", errors.New("parser must be on endtag or text to read text")
 	}
 
-	var result string
+	// The decoder emits a separate CharData token at every entity and CDATA
+	// boundary, so entity-heavy text arrives as many small fragments. Use a
+	// Builder to avoid O(n^2) string concatenation.
+	var sb strings.Builder
 	for t == Text {
-		result = result + p.Text
+		sb.WriteString(p.Text)
 		t, err = p.Next()
 		if err != nil {
 			return "", err
@@ -177,21 +180,30 @@ func (p *XMLPullParser) NextText() (string, error) {
 		}
 	}
 
-	return result, nil
+	return sb.String(), nil
 }
 
+// Skip consumes tokens until the end tag matching the element the parser is
+// currently positioned on. It is iterative (a depth counter rather than
+// recursion) so deeply nested input can't overflow the goroutine stack, and it
+// bails on EndDocument instead of looping forever on a truncated stream.
 func (p *XMLPullParser) Skip() error {
+	depth := 0
 	for {
 		tok, err := p.NextToken()
 		if err != nil {
 			return err
 		}
-		if tok == StartTag {
-			if err := p.Skip(); err != nil {
-				return err
+		switch tok {
+		case StartTag:
+			depth++
+		case EndTag:
+			if depth == 0 {
+				return nil
 			}
-		} else if tok == EndTag {
-			return nil
+			depth--
+		case EndDocument:
+			return errors.New("unexpected end of document while skipping element")
 		}
 	}
 }
@@ -238,6 +250,20 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	p.resetTokenState()
 	p.Event = EndTag
 	p.Depth--
+
+	// decoder.DecodeElement consumed this element's end token internally, so
+	// processEndToken never ran for it. Pop the namespace scope its start token
+	// pushed, mirroring processEndToken, otherwise p.Spaces/SpacesStack desync
+	// and the stack grows one entry per DecodeElement call.
+	if len(p.SpacesStack) > 0 {
+		p.SpacesStack = p.SpacesStack[:len(p.SpacesStack)-1]
+	}
+	if len(p.SpacesStack) == 0 {
+		p.Spaces = map[string]string{}
+	} else {
+		p.Spaces = p.SpacesStack[len(p.SpacesStack)-1]
+	}
+
 	p.Name = name
 	p.token = nil
 

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -85,6 +85,34 @@ func TestDecodeElementDepth(t *testing.T) {
 	p.DecodeElement(&v{})
 }
 
+func TestDecodeElementNamespaceStack(t *testing.T) {
+	crReader := func(charset string, input io.Reader) (io.Reader, error) {
+		return input, nil
+	}
+	// The first <d2> declares its own namespace (b:w). After decoding it, that
+	// scope must be popped so the parser is back to root's namespaces.
+	r := bytes.NewBufferString(`<root xmlns:a="z"><d2 xmlns:b="w">foo</d2><d2>bar</d2></root>`)
+	p := xpp.NewXMLPullParser(r, false, crReader)
+
+	type v struct{}
+
+	p.NextTag() // root
+	assert.EqualValues(t, map[string]string{"z": "a"}, p.Spaces)
+	assert.Len(t, p.SpacesStack, 1)
+
+	p.NextTag() // first <d2>, adds b:w
+	assert.EqualValues(t, map[string]string{"z": "a", "w": "b"}, p.Spaces)
+	assert.Len(t, p.SpacesStack, 2)
+
+	p.DecodeElement(&v{})
+	// Scope must be back to root's: b:w no longer leaks and the stack shrank.
+	assert.EqualValues(t, map[string]string{"z": "a"}, p.Spaces)
+	assert.Len(t, p.SpacesStack, 1)
+
+	p.NextTag() // second <d2>
+	assert.EqualValues(t, map[string]string{"z": "a"}, p.Spaces)
+}
+
 func TestXMLBase(t *testing.T) {
 	crReader := func(charset string, input io.Reader) (io.Reader, error) {
 		return input, nil


### PR DESCRIPTION
Three fixes (#14, #15, #16).

- **Skip (#14):** iterate with a depth counter instead of recursing, so deeply nested input can't overflow the goroutine stack, and bail on `EndDocument` instead of looping forever on a truncated stream. Existing `TestSkip` covers the correctness cases.
- **NextText (#15):** accumulate with `strings.Builder`. The decoder emits a separate `CharData` token at every entity and CDATA boundary, so `result = result + p.Text` was O(n^2) on entity-heavy text.
- **DecodeElement (#16):** pop the namespace scope the element's start token pushed. `decoder.DecodeElement` consumes the end token internally, so `processEndToken` never ran for it, leaving `p.Spaces`/`SpacesStack` desynced (wrong namespace resolution for the rest of the parent scope) and the stack growing one entry per call. New test `TestDecodeElementNamespaceStack` fails on the old code and passes now.

Closes #14, #15, #16.