### PR TITLE
DecodeElement: pop the namespace scope it consumed

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -238,6 +238,20 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	p.resetTokenState()
 	p.Event = EndTag
 	p.Depth--
+
+	// decoder.DecodeElement consumed this element's end token internally, so
+	// processEndToken never ran for it. Pop the namespace scope its start token
+	// pushed, mirroring processEndToken, otherwise p.Spaces/SpacesStack desync
+	// and the stack grows one entry per DecodeElement call.
+	if len(p.SpacesStack) > 0 {
+		p.SpacesStack = p.SpacesStack[:len(p.SpacesStack)-1]
+	}
+	if len(p.SpacesStack) == 0 {
+		p.Spaces = map[string]string{}
+	} else {
+		p.Spaces = p.SpacesStack[len(p.SpacesStack)-1]
+	}
+
 	p.Name = name
 	p.token = nil
 

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -85,6 +85,34 @@ func TestDecodeElementDepth(t *testing.T) {
 	p.DecodeElement(&v{})
 }
 
+func TestDecodeElementNamespaceStack(t *testing.T) {
+	crReader := func(charset string, input io.Reader) (io.Reader, error) {
+		return input, nil
+	}
+	// The first <d2> declares its own namespace (b:w). After decoding it, that
+	// scope must be popped so the parser is back to root's namespaces.
+	r := bytes.NewBufferString(`<root xmlns:a="z"><d2 xmlns:b="w">foo</d2><d2>bar</d2></root>`)
+	p := xpp.NewXMLPullParser(r, false, crReader)
+
+	type v struct{}
+
+	p.NextTag() // root
+	assert.EqualValues(t, map[string]string{"z": "a"}, p.Spaces)
+	assert.Len(t, p.SpacesStack, 1)
+
+	p.NextTag() // first <d2>, adds b:w
+	assert.EqualValues(t, map[string]string{"z": "a", "w": "b"}, p.Spaces)
+	assert.Len(t, p.SpacesStack, 2)
+
+	p.DecodeElement(&v{})
+	// Scope must be back to root's: b:w no longer leaks and the stack shrank.
+	assert.EqualValues(t, map[string]string{"z": "a"}, p.Spaces)
+	assert.Len(t, p.SpacesStack, 1)
+
+	p.NextTag() // second <d2>
+	assert.EqualValues(t, map[string]string{"z": "a"}, p.Spaces)
+}
+
 func TestXMLBase(t *testing.T) {
 	crReader := func(charset string, input io.Reader) (io.Reader, error) {
 		return input, nil


### PR DESCRIPTION
`decoder.DecodeElement` consumes the element's end token internally, so `processEndToken` never ran for it. `DecodeElement` fixed up `Depth` and `BaseStack` but not `SpacesStack`, so after any `DecodeElement` call `p.Spaces`/`SpacesStack` were desynced (the decoded child's namespaces leaked into the parent scope) and the stack grew one entry per call.

Pop the namespace scope, mirroring `processEndToken`. New test `TestDecodeElementNamespaceStack` fails on the old code and passes now.

Closes #16.