### PR TITLE
XmlBaseResolveUrl: resolve against a copy of the base

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -337,12 +337,16 @@ func (p *XMLPullParser) XmlBaseResolveUrl(u string) (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	if curr.Path != "" && u != "" && curr.Path[len(curr.Path)-1] != '/' {
+	// Work on a copy: curr is the live base held on the stack, so appending "/"
+	// to it would rewrite the base for every sibling resolved after the first
+	// relative URL in this scope.
+	base := *curr
+	if base.Path != "" && u != "" && base.Path[len(base.Path)-1] != '/' {
 		// There's no reason someone would use a path in xml:base if they
 		// didn't mean for it to be a directory
-		curr.Path = curr.Path + "/"
+		base.Path = base.Path + "/"
 	}
-	absURL := curr.ResolveReference(relURL)
+	absURL := base.ResolveReference(relURL)
 	return absURL, nil
 }
 

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -149,6 +149,24 @@ func TestXMLBase(t *testing.T) {
 	assert.Equal(t, "https://example.org/path/", p.BaseStack.Top().String())
 }
 
+func TestXmlBaseResolveUrlDoesNotMutateBase(t *testing.T) {
+	crReader := func(charset string, input io.Reader) (io.Reader, error) {
+		return input, nil
+	}
+	r := bytes.NewBufferString(`<root xml:base="https://example.org/a/b"><d/></root>`)
+	p := xpp.NewXMLPullParser(r, false, crReader)
+
+	p.NextTag() // root, base is https://example.org/a/b
+	before := p.BaseStack.Top().String()
+
+	resolved, err := p.XmlBaseResolveUrl("x")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.org/a/b/x", resolved.String())
+
+	// The stacked base must be unchanged by the resolution.
+	assert.Equal(t, before, p.BaseStack.Top().String())
+}
+
 func toNextStart(t *testing.T, p *xpp.XMLPullParser) {
 	for {
 		tok, err := p.NextToken()


### PR DESCRIPTION
`XmlBaseResolveUrl` appended `/` to `curr.Path`, where `curr` is the live base held on the stack (`BaseStack.Top()`), so it rewrote the base for every sibling resolved after the first relative URL in that scope. Resolve against a copy instead. New test fails on the old code and passes now.

Closes #20.