### PR TITLE
Fix BaseStack push/pop asymmetry

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -272,16 +272,12 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	p.Name = name
 	p.token = nil
 
-	// if the token we decoded had an xml:base attribute, we need to pop it
-	// from the stack
-	// Note: this means it is up to the caller of DecodeElement to save the curent xml:base
-	// before calling DecodeElement if it needs to resolve relative URLs in `v`
-	for _, attr := range startToken.Attr {
-		if attr.Name.Space == xmlNSURI && attr.Name.Local == "base" {
-			p.popBase()
-			break
-		}
-	}
+	// decoder.DecodeElement consumed this element's end token internally, so
+	// processEndToken never ran for it. Pop the base its start token pushed
+	// (pushBase pushes one per element), mirroring processEndToken. Callers that
+	// need the element's xml:base to resolve relative URLs in `v` must capture
+	// it before calling DecodeElement.
+	p.popBase()
 	return nil
 }
 
@@ -446,27 +442,35 @@ func (p *XMLPullParser) popBase() string {
 
 // Searches current attributes for xml:base and updates the urlStack
 func (p *XMLPullParser) pushBase() error {
+	// Push a base entry for every element so the stack stays balanced with the
+	// per-element pop in processEndToken and DecodeElement. An element with its
+	// own xml:base resolves it against the parent's base; otherwise it inherits
+	// the parent's base unchanged. Pushing conditionally (only for xml:base
+	// elements) while popping unconditionally would pop an ancestor's base when
+	// a plain element closes.
+	parent := p.BaseStack.Top()
+
 	var base string
-	// search list of attrs for "xml:base"
 	for _, attr := range p.Attrs {
 		if attr.Name.Local == "base" && attr.Name.Space == xmlNSURI {
 			base = attr.Value
 			break
 		}
 	}
+
 	if base == "" {
-		// no base attribute found
+		p.BaseStack.push(parent)
 		return nil
 	}
 
 	newURL, err := url.Parse(base)
 	if err != nil {
+		// Still push so the stack stays balanced with the matching pop.
+		p.BaseStack.push(parent)
 		return err
 	}
-
-	topURL := p.BaseStack.Top()
-	if topURL != nil {
-		newURL = topURL.ResolveReference(newURL)
+	if parent != nil {
+		newURL = parent.ResolveReference(newURL)
 	}
 	p.BaseStack.push(newURL)
 	return nil

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -197,6 +197,28 @@ func TestXmlBaseResolveUrlDoesNotMutateBase(t *testing.T) {
 	eq(t, p.BaseStack.Top().String(), before)
 }
 
+func TestXmlBaseSurvivesContainerClose(t *testing.T) {
+	crReader := func(charset string, input io.Reader) (io.Reader, error) {
+		return input, nil
+	}
+	// <child> has no xml:base of its own; closing it must not discard the root's
+	// base for the following <after>.
+	r := bytes.NewBufferString(`<root xml:base="http://example.org/a/"><child></child><after></after></root>`)
+	p := xpp.NewXMLPullParser(r, false, crReader)
+
+	p.NextTag() // <root>
+	p.NextTag() // <child>
+	p.NextTag() // </child>  (processEndToken pops a base)
+	p.NextTag() // <after>
+	eq(t, p.Name, "after")
+
+	got, err := p.XmlBaseResolveUrl("rel")
+	noErr(t, err)
+	if got == nil || got.String() != "http://example.org/a/rel" {
+		t.Errorf("resolved = %v, want http://example.org/a/rel", got)
+	}
+}
+
 func toNextStart(t *testing.T, p *xpp.XMLPullParser) {
 	for {
 		tok, err := p.NextToken()


### PR DESCRIPTION
`pushBase` only pushed when an element had its own `xml:base`, but `processEndToken` and `DecodeElement` popped unconditionally. So closing any element *without* its own base popped an **ancestor's** base off the stack, desyncing xml:base resolution for everything after it (relative URLs in later siblings stopped resolving).

Fix: push a base entry for every element (its own resolved `xml:base`, or the parent's base inherited), matching the per-element pop. This mirrors how `SpacesStack` already works. New test `TestXmlBaseSurvivesContainerClose` fails on the old code; the existing `TestXMLBase` still passes. No API or Go-version change (stays go 1.19).

Closes #24.