### PR TITLE
Poison the parser when DecodeElement fails mid-element

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -65,6 +65,11 @@ type XMLPullParser struct {
 
 	decoder *xml.Decoder
 	token   interface{}
+	// err is sticky: once the parser state can no longer be trusted (a
+	// DecodeElement error left the decoder somewhere inside an element),
+	// every subsequent token call returns it instead of running on
+	// desynced Depth/SpacesStack/BaseStack state.
+	err error
 }
 
 func NewXMLPullParser(r io.Reader, strict bool, cr CharsetReader) *XMLPullParser {
@@ -131,6 +136,10 @@ func (p *XMLPullParser) Next() (event XMLEventType, err error) {
 }
 
 func (p *XMLPullParser) NextToken() (event XMLEventType, err error) {
+	if p.err != nil {
+		return p.Event, p.err
+	}
+
 	// Clear any state held for the previous token
 	p.resetTokenState()
 
@@ -245,6 +254,12 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	// Consumes all tokens until the matching end token.
 	err := p.decoder.DecodeElement(v, &startToken)
 	if err != nil {
+		// The decoder stopped somewhere inside the element, so an unknown
+		// number of tokens was consumed and Depth, SpacesStack and BaseStack
+		// no longer match the decoder's position. The parser cannot safely
+		// continue; poison it so subsequent calls error instead of popping
+		// stacks for elements they never saw opened.
+		p.err = fmt.Errorf("parser state desynced by DecodeElement error: %w", err)
 		return err
 	}
 
@@ -379,7 +394,11 @@ func (p *XMLPullParser) processStartToken(t xml.StartElement) {
 
 func (p *XMLPullParser) processEndToken(t xml.EndElement) {
 	p.Depth--
-	p.SpacesStack = p.SpacesStack[:len(p.SpacesStack)-1]
+	// Guard the pop: an end tag without a tracked start (possible only if
+	// internal invariants were violated) must not panic.
+	if len(p.SpacesStack) > 0 {
+		p.SpacesStack = p.SpacesStack[:len(p.SpacesStack)-1]
+	}
 	if len(p.SpacesStack) == 0 {
 		p.Spaces = map[string]string{}
 	} else {

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -415,3 +415,83 @@ func TestSpecialCases(t *testing.T) {
 		})
 	}
 }
+
+// A DecodeElement unmarshal error leaves the decoder mid-element. The parser
+// must refuse to continue rather than run with desynced stacks, which used to
+// end in a slice-bounds panic at the enclosing end tags (issue #28).
+func TestDecodeElementErrorPoisonsParser(t *testing.T) {
+	doc := `<root><d2><inner><n>notanumber</n><m>y</m></inner></d2><d3/></root>`
+	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+
+	// Position on <d2>.
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if tok == xpp.StartTag && p.Name == "d2" {
+			break
+		}
+	}
+
+	var v struct {
+		Inner struct {
+			N int `xml:"n"`
+		} `xml:"inner"`
+	}
+	if err := p.DecodeElement(&v); err == nil {
+		t.Fatal("DecodeElement should fail on notanumber -> int")
+	}
+
+	// Every subsequent call must return an error; pulling tokens through the
+	// rest of the document must not panic at </d2> or </root>.
+	for i := 0; i < 20; i++ {
+		if _, err := p.NextToken(); err == nil {
+			t.Fatalf("NextToken call %d after failed DecodeElement should error", i)
+		}
+	}
+	if _, err := p.Next(); err == nil {
+		t.Fatal("Next after failed DecodeElement should error")
+	}
+	if _, err := p.NextTag(); err == nil {
+		t.Fatal("NextTag after failed DecodeElement should error")
+	}
+	if err := p.Skip(); err == nil {
+		t.Fatal("Skip after failed DecodeElement should error")
+	}
+}
+
+// A successful DecodeElement must not set the sticky error; the parser
+// continues normally.
+func TestDecodeElementSuccessDoesNotPoison(t *testing.T) {
+	doc := `<root><d2><n>42</n></d2><d3>x</d3></root>`
+	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if tok == xpp.StartTag && p.Name == "d2" {
+			break
+		}
+	}
+
+	var v struct {
+		N int `xml:"n"`
+	}
+	if err := p.DecodeElement(&v); err != nil {
+		t.Fatalf("DecodeElement: %v", err)
+	}
+	if v.N != 42 {
+		t.Fatalf("N = %d, want 42", v.N)
+	}
+
+	tok, err := p.NextTag()
+	if err != nil {
+		t.Fatalf("NextTag after successful DecodeElement: %v", err)
+	}
+	if tok != xpp.StartTag || p.Name != "d3" {
+		t.Fatalf("got %s %q, want StartTag d3", p.EventName(tok), p.Name)
+	}
+}


### PR DESCRIPTION
Fixes #28.

When `decoder.DecodeElement` returns an unmarshal error (for example a type conversion failure), it stops somewhere inside the element with an unknown number of tokens consumed. The parser's `Depth`, `SpacesStack` and `BaseStack` no longer match the decoder's position, but `p.Event` still claimed `StartTag`, so callers could keep pulling tokens. Every orphaned `EndElement` then popped `SpacesStack` unguarded, and the reproduction from the issue ends in `panic: runtime error: slice bounds out of range [:-1]` at the document's closing tag, with namespace and xml:base attribution silently wrong before that.

Two changes:

- `DecodeElement` sets a sticky error on its failure path. `NextToken` returns it on every subsequent call, and `Next`, `NextTag`, `NextText` and `Skip` all funnel through `NextToken`, so the whole API refuses to run on desynced state. The original unmarshal error is still what `DecodeElement` itself returns; the sticky error wraps it with context.
- The `SpacesStack` pop in `processEndToken` is guarded, matching the guard `DecodeElement`'s own pop already had, so an internal invariant violation can never surface as a panic.

Tests: the issue's reproduction (decode into a struct with an int field over text, then keep pulling tokens through the enclosing end tags), asserting every entry point errors and nothing panics; it panics on master. A companion test pins that a successful `DecodeElement` does not poison and parsing continues normally.