### PR TITLE
Populate Space on EndTag events

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -264,6 +264,7 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	}
 
 	name := p.Name
+	space := p.Space
 
 	// Need to set the "current" token name/event
 	// to the previous StartTag event's name
@@ -285,6 +286,7 @@ func (p *XMLPullParser) DecodeElement(v interface{}) error {
 	}
 
 	p.Name = name
+	p.Space = space
 	p.token = nil
 
 	// decoder.DecodeElement consumed this element's end token internally, so
@@ -405,6 +407,7 @@ func (p *XMLPullParser) processEndToken(t xml.EndElement) {
 		p.Spaces = p.SpacesStack[len(p.SpacesStack)-1]
 	}
 	p.Name = t.Name.Local
+	p.Space = t.Name.Space
 	p.popBase()
 }
 

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -495,3 +495,57 @@ func TestDecodeElementSuccessDoesNotPoison(t *testing.T) {
 		t.Fatalf("got %s %q, want StartTag d3", p.EventName(tok), p.Name)
 	}
 }
+
+// EndTag events must carry the element's namespace so ExpectAll can validate
+// end tags (issue #29).
+func TestEndTagSpacePopulated(t *testing.T) {
+	doc := `<a:x xmlns:a="http://ns">v</a:x>`
+	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatalf("next: %v", err)
+		}
+		if tok == xpp.EndTag {
+			break
+		}
+		if tok == xpp.EndDocument {
+			t.Fatal("no end tag seen")
+		}
+	}
+
+	if p.Space != "http://ns" {
+		t.Fatalf("Space on EndTag = %q, want %q", p.Space, "http://ns")
+	}
+	if err := p.ExpectAll(xpp.EndTag, "http://ns", "x"); err != nil {
+		t.Fatalf("ExpectAll on end tag: %v", err)
+	}
+}
+
+// The synthetic EndTag left behind by DecodeElement must carry the decoded
+// element's namespace too.
+func TestDecodeElementEndTagSpace(t *testing.T) {
+	doc := `<root xmlns:a="http://ns"><a:x><n>1</n></a:x></root>`
+	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatalf("next: %v", err)
+		}
+		if tok == xpp.StartTag && p.Name == "x" {
+			break
+		}
+	}
+
+	var v struct {
+		N int `xml:"n"`
+	}
+	if err := p.DecodeElement(&v); err != nil {
+		t.Fatalf("DecodeElement: %v", err)
+	}
+	if err := p.ExpectAll(xpp.EndTag, "http://ns", "x"); err != nil {
+		t.Fatalf("ExpectAll on synthetic end tag: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #29.

`resetTokenState` clears `Space` and `processEndToken` only set `Name`, even though `xml.EndElement.Name.Space` is available. On any end tag `p.Space` was therefore `""`, so `ExpectAll(EndTag, "http://ns", "x")` was a guaranteed failure; the exported end-tag namespace validation API was unusable.

`processEndToken` now sets `Space` from the end token. The synthetic EndTag that `DecodeElement` leaves behind restores the decoded element's namespace the same way, so both end-tag paths agree.

Tests: `ExpectAll` with a concrete namespace on a real end tag and on a `DecodeElement` synthetic end tag; both fail on master. Also ran gofeed's full test suite against this branch via a local module replace: green, so the newly populated field does not perturb the main consumer (gofeed only uses wildcard-space `Expect`).