### PR TITLE
Prefer un-namespaced attributes in Attribute lookup

### DIFF
--- a/xpp.go
+++ b/xpp.go
@@ -222,13 +222,26 @@ func (p *XMLPullParser) Skip() error {
 	}
 }
 
+// Attribute returns the value of the named attribute, preferring an
+// un-namespaced attribute over foreign-namespaced ones sharing the local
+// name (a document-order first match let e.g. an earlier xlink:href shadow
+// the plain href). A namespaced attribute is still returned when no plain
+// one exists.
 func (p *XMLPullParser) Attribute(name string) string {
+	var fallback string
+	found := false
 	for _, attr := range p.Attrs {
 		if attr.Name.Local == name {
-			return attr.Value
+			if attr.Name.Space == "" {
+				return attr.Value
+			}
+			if !found {
+				fallback = attr.Value
+				found = true
+			}
 		}
 	}
-	return ""
+	return fallback
 }
 
 func (p *XMLPullParser) Expect(event XMLEventType, name string) (err error) {

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -549,3 +549,30 @@ func TestDecodeElementEndTagSpace(t *testing.T) {
 		t.Fatalf("ExpectAll on synthetic end tag: %v", err)
 	}
 }
+
+// A foreign-namespaced attribute must not shadow the plain attribute with
+// the same local name (issue #31).
+func TestAttributePrefersUnNamespaced(t *testing.T) {
+	doc := `<root xmlns:o="http://other" o:href="WRONG" href="right"/>`
+	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+
+	if _, err := p.NextTag(); err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if got := p.Attribute("href"); got != "right" {
+		t.Fatalf("Attribute(href) = %q, want %q", got, "right")
+	}
+}
+
+// When only a namespaced attribute exists it is still returned by local name.
+func TestAttributeNamespacedFallback(t *testing.T) {
+	doc := `<root xmlns:o="http://other" o:href="only"/>`
+	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+
+	if _, err := p.NextTag(); err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if got := p.Attribute("href"); got != "only" {
+		t.Fatalf("Attribute(href) = %q, want %q", got, "only")
+	}
+}


### PR DESCRIPTION
Fixes #31.

`Attribute` returned the first attribute whose local name matched, in document order, so `<root o:href="WRONG" href="right"/>` returned the foreign-namespaced value. It now prefers the un-namespaced attribute and falls back to a namespaced one only when no plain attribute exists, which preserves the current behavior for elements that only carry a prefixed attribute.

A fully namespace-aware variant (`AttributeNS`) is left for the v2 API work in #34.

Tests: the shadowing case (fails on master) and the namespaced-only fallback. gofeed's full suite also passes against this branch via a local module replace.