### PR TITLE
goxpp v2: encapsulate parser state, rework errors, fix namespaces and xml:base

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,49 +3,58 @@
 [![Build Status](https://github.com/mmcdole/goxpp/actions/workflows/ci.yml/badge.svg)](https://github.com/mmcdole/goxpp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/mmcdole/goxpp/branch/master/graph/badge.svg)](https://codecov.io/gh/mmcdole/goxpp)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
-[![Go Reference](https://pkg.go.dev/badge/github.com/mmcdole/goxpp.svg)](https://pkg.go.dev/github.com/mmcdole/goxpp)
+[![Go Reference](https://pkg.go.dev/badge/github.com/mmcdole/goxpp/v2.svg)](https://pkg.go.dev/github.com/mmcdole/goxpp/v2)
 
-A lightweight XML Pull Parser for Go, inspired by [Java's XMLPullParser](http://www.xmlpull.org/v1/download/unpacked/doc/quick_intro.html). It provides fine-grained control over XML parsing with a simple, intuitive API.
+A lightweight XML pull parser for Go, inspired by [Java's XMLPullParser](http://www.xmlpull.org/v1/download/unpacked/doc/quick_intro.html). It provides fine-grained control over XML parsing with a small, cursor-style API.
 
 ## Features
 
 - Pull-based parsing for fine-grained document control
+- Scoped namespace and xml:base tracking
 - Efficient navigation and element skipping
-- Simple, idiomatic Go API
+- Errors you can match with `errors.As` / `errors.Is`
 
 ## Installation
 
 ```bash
-go get github.com/mmcdole/goxpp
+go get github.com/mmcdole/goxpp/v2
 ```
+
+v1 remains available at `github.com/mmcdole/goxpp` and receives critical fixes on the `v1` branch.
 
 ## Quick Start
 
 ```go
-import "github.com/mmcdole/goxpp"
+import (
+    "encoding/xml"
 
-// Parse RSS feed
+    xpp "github.com/mmcdole/goxpp/v2"
+)
+
+// Parse an RSS feed
 file, _ := os.Open("feed.rss")
-p := xpp.NewXMLPullParser(file, false, nil)
+d := xml.NewDecoder(file)
+d.Strict = false
+p := xpp.New(d)
 
-// Find channel element
+// Find the channel element
 for tok, err := p.NextTag(); tok != xpp.EndDocument; tok, err = p.NextTag() {
     if err != nil {
         return err
     }
-    if tok == xpp.StartTag && p.Name == "channel" {
+    if tok == xpp.StartTag && p.Name() == "channel" {
         // Process channel contents
         for tok, err = p.NextTag(); tok != xpp.EndTag; tok, err = p.NextTag() {
             if err != nil {
                 return err
             }
             if tok == xpp.StartTag {
-                switch p.Name {
+                switch p.Name() {
                 case "title":
                     title, _ := p.NextText()
                     fmt.Printf("Feed: %s\n", title)
                 case "item":
-                    // Get item title and skip rest
+                    // Get the item title and skip the rest
                     p.NextTag()
                     title, _ := p.NextText()
                     fmt.Printf("Item: %s\n", title)
@@ -66,11 +75,20 @@ for tok, err := p.NextTag(); tok != xpp.EndDocument; tok, err = p.NextTag() {
 - `StartTag`, `EndTag`
 - `Text`, `Comment`
 - `ProcessingInstruction`, `Directive`
-- `IgnorableWhitespace`
+
+## Migrating from v1
+
+The v2 changes are listed in [#34](https://github.com/mmcdole/goxpp/issues/34). In short:
+
+- Construct with `xpp.New(*xml.Decoder)`; configure strictness and charset conversion on the decoder.
+- Cursor state moved from exported fields to methods: `p.Name` becomes `p.Name()`, and so on.
+- `Namespaces()` maps prefix to URI; `PrefixForURI` covers the reverse lookup.
+- `BaseURL()` exposes the in-scope xml:base; resolving URLs against it is the caller's concern.
+- Advancement calls after `EndDocument` return `io.EOF`; positional failures are `*xpp.ExpectError`.
 
 ## Documentation
 
-For detailed documentation and examples, visit [pkg.go.dev](https://pkg.go.dev/github.com/mmcdole/goxpp).
+For detailed documentation and examples, visit [pkg.go.dev](https://pkg.go.dev/github.com/mmcdole/goxpp/v2).
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mmcdole/goxpp
+module github.com/mmcdole/goxpp/v2
 
-go 1.19
+go 1.21

--- a/xpp.go
+++ b/xpp.go
@@ -1,3 +1,11 @@
+// Package xpp implements a cursor-style XML pull parser over encoding/xml,
+// modeled on Java's XmlPullParser.
+//
+// The parser is a cursor: an advancement call (Next, NextToken, NextTag)
+// positions it on a token, and accessor methods (Event, Name, Space, Text,
+// Attrs, Depth) describe the token the parser is currently on. Convenience
+// methods (Expect, NextText, Skip, DecodeElement) operate on the current
+// token.
 package xpp
 
 import (
@@ -9,13 +17,15 @@ import (
 	"strings"
 )
 
-type XMLEventType int
-type CharsetReader func(charset string, input io.Reader) (io.Reader, error)
-
-const xmlNSURI = "http://www.w3.org/XML/1998/namespace"
+// EventType identifies the kind of token the parser is positioned on.
+type EventType int
 
 const (
-	StartDocument XMLEventType = iota
+	// StartDocument is the parser's state before the first advancement
+	// call. It is never returned by Next or NextToken.
+	StartDocument EventType = iota
+	// EndDocument is returned once when the document ends; every
+	// advancement call after that returns io.EOF.
 	EndDocument
 	StartTag
 	EndTag
@@ -23,149 +33,170 @@ const (
 	Comment
 	ProcessingInstruction
 	Directive
-	IgnorableWhitespace // TODO: ?
-	// TODO: CDSECT ?
 )
 
-type urlStack []*url.URL
-
-func (s *urlStack) push(u *url.URL) {
-	*s = append([]*url.URL{u}, *s...)
-}
-
-func (s *urlStack) pop() *url.URL {
-	if s == nil || len(*s) == 0 {
-		return nil
+func (e EventType) String() string {
+	switch e {
+	case StartDocument:
+		return "StartDocument"
+	case EndDocument:
+		return "EndDocument"
+	case StartTag:
+		return "StartTag"
+	case EndTag:
+		return "EndTag"
+	case Text:
+		return "Text"
+	case Comment:
+		return "Comment"
+	case ProcessingInstruction:
+		return "ProcessingInstruction"
+	case Directive:
+		return "Directive"
 	}
-	var top *url.URL
-	top, *s = (*s)[0], (*s)[1:]
-	return top
+	return fmt.Sprintf("EventType(%d)", int(e))
 }
 
-func (s *urlStack) Top() *url.URL {
-	if s == nil || len(*s) == 0 {
-		return nil
-	}
-	return (*s)[0]
+const xmlNSURI = "http://www.w3.org/XML/1998/namespace"
+
+// ExpectError reports a positional assertion failure: the parser was not on
+// the event or name the caller required. It is returned by Expect and
+// ExpectAll, and by the preconditions of NextTag, NextText, Skip and
+// DecodeElement. Want fields hold "*" where anything was acceptable.
+type ExpectError struct {
+	WantEvent           EventType
+	WantSpace, WantName string
+	GotEvent            EventType
+	GotSpace, GotName   string
+	Offset              int64
 }
 
-type XMLPullParser struct {
-	// Document State
-	Spaces      map[string]string
-	SpacesStack []map[string]string
-	BaseStack   urlStack
+func (e *ExpectError) Error() string {
+	return fmt.Sprintf("xpp: expected space:%s name:%s event:%s but got space:%s name:%s event:%s at offset %d",
+		e.WantSpace, e.WantName, e.WantEvent, e.GotSpace, e.GotName, e.GotEvent, e.Offset)
+}
 
-	// Token State
-	Depth int
-	Event XMLEventType
-	Attrs []xml.Attr
-	Name  string
-	Space string
-	Text  string
+// nsScope is one element's namespace scope: the full merged prefix -> URI
+// view, plus the element's own declarations in document order (needed for
+// PrefixForURI's most-recently-declared rule).
+type nsScope struct {
+	bindings map[string]string
+	decls    []nsDecl
+}
 
+type nsDecl struct {
+	prefix, uri string
+}
+
+// Parser is a cursor-style XML pull parser. Create one with New; the zero
+// value returns an error from every advancement call.
+type Parser struct {
 	decoder *xml.Decoder
-	token   interface{}
-	// err is sticky: once the parser state can no longer be trusted (a
-	// DecodeElement error left the decoder somewhere inside an element),
-	// every subsequent token call returns it instead of running on
-	// desynced Depth/SpacesStack/BaseStack state.
-	err error
+	token   xml.Token
+
+	event EventType
+	name  string
+	space string
+	text  string
+	attrs []xml.Attr
+	depth int
+
+	nsStack   []nsScope
+	baseStack []*url.URL
+
+	// pendingPop defers the scope/depth pop for an EndTag until the next
+	// advancement call, so Depth, Namespaces and BaseURL describe the
+	// element itself while the cursor is on its end tag, matching the
+	// behavior at its start tag.
+	pendingPop bool
+	docEnded   bool
+	err        error
 }
 
-func NewXMLPullParser(r io.Reader, strict bool, cr CharsetReader) *XMLPullParser {
-	d := xml.NewDecoder(r)
-	d.Strict = strict
-	d.CharsetReader = cr
-	return NewXMLPullParserWithDecoder(d)
+// New returns a parser reading from d. Configure strictness and charset
+// conversion on the decoder directly (d.Strict, d.CharsetReader); the parser
+// adds no configuration of its own.
+func New(d *xml.Decoder) *Parser {
+	return &Parser{decoder: d, event: StartDocument}
 }
 
-// NewXMLPullParserWithDecoder creates a new XMLPullParser with a custom decoder
-func NewXMLPullParserWithDecoder(d *xml.Decoder) *XMLPullParser {
-	return &XMLPullParser{
-		decoder: d,
-		Event:   StartDocument,
-		Depth:   0,
-		Spaces:  map[string]string{},
+// NextToken advances to the next raw token, including comments, processing
+// instructions and directives. The first call after the document ends
+// returns (EndDocument, nil); every call after that returns io.EOF. After a
+// decoder error or a failed DecodeElement the parser is poisoned and every
+// call returns that error; see Err.
+func (p *Parser) NextToken() (EventType, error) {
+	if p.err != nil {
+		return p.event, p.err
 	}
-}
+	if p.decoder == nil {
+		p.err = errors.New("xpp: parser has no decoder; use New")
+		return p.event, p.err
+	}
+	if p.docEnded {
+		return p.event, io.EOF
+	}
 
-func (p *XMLPullParser) NextTag() (event XMLEventType, err error) {
-	t, err := p.Next()
+	p.applyPendingPop()
+	p.resetTokenState()
+
+	tok, err := p.decoder.Token()
 	if err != nil {
-		return event, err
-	}
-
-	for t == Text && p.IsWhitespace() {
-		t, err = p.Next()
-		if err != nil {
-			return event, err
+		if err == io.EOF {
+			p.token = nil
+			p.event = EndDocument
+			p.docEnded = true
+			return p.event, nil
 		}
+		p.err = err
+		return p.event, err
 	}
 
-	if t != StartTag && t != EndTag {
-		return event, fmt.Errorf("expected starttag or endtag but got %s at offset: %d", p.EventName(t), p.decoder.InputOffset())
-	}
-
-	return t, nil
+	p.token = xml.CopyToken(tok)
+	p.processToken(p.token)
+	return p.event, nil
 }
 
-func (p *XMLPullParser) Next() (event XMLEventType, err error) {
+// Next advances like NextToken but skips Comment, ProcessingInstruction and
+// Directive tokens.
+func (p *Parser) Next() (EventType, error) {
 	for {
-		event, err = p.NextToken()
+		event, err := p.NextToken()
 		if err != nil {
 			return event, err
 		}
-
-		// Return immediately after encountering a StartTag
-		// EndTag, Text, EndDocument
-		if event == StartTag ||
-			event == EndTag ||
-			event == EndDocument ||
-			event == Text {
-			return event, nil
-		}
-
-		// Skip Comment/Directive and ProcessingInstruction
-		if event == Comment ||
-			event == Directive ||
-			event == ProcessingInstruction {
+		switch event {
+		case Comment, ProcessingInstruction, Directive:
 			continue
 		}
 		return event, nil
 	}
 }
 
-func (p *XMLPullParser) NextToken() (event XMLEventType, err error) {
-	if p.err != nil {
-		return p.Event, p.err
-	}
-
-	// Clear any state held for the previous token
-	p.resetTokenState()
-
-	token, err := p.decoder.Token()
+// NextTag advances past any whitespace text and returns the next StartTag or
+// EndTag. Anything else is an error.
+func (p *Parser) NextTag() (EventType, error) {
+	t, err := p.Next()
 	if err != nil {
-		if err == io.EOF {
-			// XML decoder returns the EOF as an error
-			// but we want to return it as a valid
-			// EndDocument token instead
-			p.token = nil
-			p.Event = EndDocument
-			return p.Event, nil
-		}
-		return event, err
+		return t, err
 	}
-
-	p.token = xml.CopyToken(token)
-	p.processToken(p.token)
-	p.Event = p.EventType(p.token)
-
-	return p.Event, nil
+	for t == Text && p.IsWhitespace() {
+		t, err = p.Next()
+		if err != nil {
+			return t, err
+		}
+	}
+	if t != StartTag && t != EndTag {
+		return t, p.expectErr(StartTag, "*", "*")
+	}
+	return t, nil
 }
 
-func (p *XMLPullParser) NextText() (string, error) {
-	if p.Event != StartTag {
-		return "", errors.New("parser must be on starttag to get nexttext()")
+// NextText requires the parser to be on a StartTag, consumes the element's
+// text content, and leaves the parser on the matching EndTag.
+func (p *Parser) NextText() (string, error) {
+	if p.event != StartTag {
+		return "", p.expectErr(StartTag, "*", "*")
 	}
 
 	t, err := p.Next()
@@ -173,35 +204,30 @@ func (p *XMLPullParser) NextText() (string, error) {
 		return "", err
 	}
 
-	if t != EndTag && t != Text {
-		return "", errors.New("parser must be on endtag or text to read text")
-	}
-
 	// The decoder emits a separate CharData token at every entity and CDATA
 	// boundary, so entity-heavy text arrives as many small fragments. Use a
-	// Builder to avoid O(n^2) string concatenation.
+	// Builder to avoid quadratic string concatenation.
 	var sb strings.Builder
 	for t == Text {
-		sb.WriteString(p.Text)
+		sb.WriteString(p.text)
 		t, err = p.Next()
 		if err != nil {
 			return "", err
 		}
-
-		if t != EndTag && t != Text {
-			errstr := fmt.Sprintf("event text must be immediately followed by endtag or text but got %s", p.EventName(t))
-			return "", errors.New(errstr)
-		}
 	}
-
+	if t != EndTag {
+		return "", p.expectErr(EndTag, "*", "*")
+	}
 	return sb.String(), nil
 }
 
-// Skip consumes tokens until the end tag matching the element the parser is
-// currently positioned on. It is iterative (a depth counter rather than
-// recursion) so deeply nested input can't overflow the goroutine stack, and it
-// bails on EndDocument instead of looping forever on a truncated stream.
-func (p *XMLPullParser) Skip() error {
+// Skip requires the parser to be on a StartTag and consumes tokens through
+// the matching end tag. It is iterative (a depth counter rather than
+// recursion) so deeply nested input can't overflow the goroutine stack.
+func (p *Parser) Skip() error {
+	if p.event != StartTag {
+		return p.expectErr(StartTag, "*", "*")
+	}
 	depth := 0
 	for {
 		tok, err := p.NextToken()
@@ -217,20 +243,77 @@ func (p *XMLPullParser) Skip() error {
 			}
 			depth--
 		case EndDocument:
-			return errors.New("unexpected end of document while skipping element")
+			return errors.New("xpp: document ended while skipping element")
 		}
 	}
 }
 
-// Attribute returns the value of the named attribute, preferring an
-// un-namespaced attribute over foreign-namespaced ones sharing the local
-// name (a document-order first match let e.g. an earlier xlink:href shadow
-// the plain href). A namespaced attribute is still returned when no plain
-// one exists.
-func (p *XMLPullParser) Attribute(name string) string {
+// DecodeElement requires the parser to be on a StartTag and unmarshals the
+// element into v using encoding/xml. On success the cursor is left on the
+// element's end tag. On failure the decoder has stopped at an unknown
+// position inside the element, so the parser is poisoned: DecodeElement
+// returns the decoder's error and every later call returns the wrapped form.
+func (p *Parser) DecodeElement(v any) error {
+	if p.err != nil {
+		return p.err
+	}
+	if p.event != StartTag {
+		return p.expectErr(StartTag, "*", "*")
+	}
+
+	start := p.token.(xml.StartElement)
+	name, space := p.name, p.space
+
+	if err := p.decoder.DecodeElement(v, &start); err != nil {
+		p.err = fmt.Errorf("xpp: parser state desynced by DecodeElement error: %w", err)
+		return err
+	}
+
+	// The decoder consumed through the matching end tag; present the cursor
+	// as that end tag. The pending pop keeps Depth, Namespaces and BaseURL
+	// describing the element until the next advancement, exactly as for an
+	// end tag delivered by NextToken.
+	p.resetTokenState()
+	p.token = nil
+	p.event = EndTag
+	p.name = name
+	p.space = space
+	p.pendingPop = true
+	return nil
+}
+
+// Event returns the type of the token the parser is on. Before the first
+// advancement call it is StartDocument.
+func (p *Parser) Event() EventType { return p.event }
+
+// Name returns the local name of the current start or end tag.
+func (p *Parser) Name() string { return p.name }
+
+// Space returns the namespace URI of the current start or end tag.
+func (p *Parser) Space() string { return p.space }
+
+// Text returns the content of the current Text, Comment or Directive token.
+func (p *Parser) Text() string { return p.text }
+
+// Depth returns the element nesting depth of the current token. An EndTag
+// reports the same depth as its matching StartTag; the root element is
+// depth 1.
+func (p *Parser) Depth() int { return p.depth }
+
+// Attrs returns the attributes of the current StartTag. The slice is the
+// parser's live per-token slice: it is valid until the next advancement
+// call, and callers may modify attribute values in place (later reads
+// through Attribute see the modification).
+func (p *Parser) Attrs() []xml.Attr { return p.attrs }
+
+// Attribute returns the value of the named attribute on the current
+// StartTag, or "" if absent. Matching is exact and prefers an un-namespaced
+// attribute; a namespaced attribute is returned only when no plain one
+// shares the local name.
+func (p *Parser) Attribute(name string) string {
 	var fallback string
 	found := false
-	for _, attr := range p.Attrs {
+	for _, attr := range p.attrs {
 		if attr.Name.Local == name {
 			if attr.Name.Space == "" {
 				return attr.Value
@@ -244,269 +327,207 @@ func (p *XMLPullParser) Attribute(name string) string {
 	return fallback
 }
 
-func (p *XMLPullParser) Expect(event XMLEventType, name string) (err error) {
+// IsWhitespace reports whether the current Text token is entirely
+// whitespace.
+func (p *Parser) IsWhitespace() bool { return strings.TrimSpace(p.text) == "" }
+
+// InputOffset returns the input stream byte offset of the current decoder
+// position.
+func (p *Parser) InputOffset() int64 {
+	if p.decoder == nil {
+		return 0
+	}
+	return p.decoder.InputOffset()
+}
+
+// Err returns the sticky error, or nil while the parser is healthy. It is
+// set by a decoder error or a failed DecodeElement, after which every
+// advancement call returns it.
+func (p *Parser) Err() error { return p.err }
+
+// Expect returns nil when the parser is on the given event with the given
+// local name. Name matching is case-insensitive, a documented leniency for
+// real-world feed input; "*" matches any name.
+func (p *Parser) Expect(event EventType, name string) error {
 	return p.ExpectAll(event, "*", name)
 }
 
-func (p *XMLPullParser) ExpectAll(event XMLEventType, space string, name string) (err error) {
-	if !(p.Event == event && (strings.EqualFold(p.Space, space) || space == "*") && (strings.EqualFold(p.Name, name) || name == "*")) {
-		err = fmt.Errorf("expected space:%s name:%s event:%s but got space:%s name:%s event:%s at offset: %d", space, name, p.EventName(event), p.Space, p.Name, p.EventName(p.Event), p.decoder.InputOffset())
+// ExpectAll is Expect with an additional namespace assertion, matched the
+// same way.
+func (p *Parser) ExpectAll(event EventType, space, name string) error {
+	if p.event == event &&
+		(space == "*" || strings.EqualFold(p.space, space)) &&
+		(name == "*" || strings.EqualFold(p.name, name)) {
+		return nil
 	}
-	return
+	return &ExpectError{
+		WantEvent: event, WantSpace: space, WantName: name,
+		GotEvent: p.event, GotSpace: p.space, GotName: p.name,
+		Offset: p.InputOffset(),
+	}
 }
 
-func (p *XMLPullParser) DecodeElement(v interface{}) error {
-	if p.Event != StartTag {
-		return errors.New("decodeelement can only be called from a starttag event")
+// Namespaces returns the prefix -> URI bindings in scope for the current
+// element, with prefix case preserved. The default namespace is bound to
+// the empty prefix. The map is a snapshot, safe to retain and modify.
+func (p *Parser) Namespaces() map[string]string {
+	out := map[string]string{}
+	if n := len(p.nsStack); n > 0 {
+		for k, v := range p.nsStack[n-1].bindings {
+			out[k] = v
+		}
 	}
+	return out
+}
 
-	//tok := &p.token
-
-	startToken := p.token.(xml.StartElement)
-
-	// Consumes all tokens until the matching end token.
-	err := p.decoder.DecodeElement(v, &startToken)
-	if err != nil {
-		// The decoder stopped somewhere inside the element, so an unknown
-		// number of tokens was consumed and Depth, SpacesStack and BaseStack
-		// no longer match the decoder's position. The parser cannot safely
-		// continue; poison it so subsequent calls error instead of popping
-		// stacks for elements they never saw opened.
-		p.err = fmt.Errorf("parser state desynced by DecodeElement error: %w", err)
-		return err
+// PrefixForURI returns the most recently declared in-scope prefix bound to
+// uri. It reports ok=false when no in-scope prefix is bound to it.
+func (p *Parser) PrefixForURI(uri string) (prefix string, ok bool) {
+	uri = strings.TrimSpace(uri)
+	for i := len(p.nsStack) - 1; i >= 0; i-- {
+		decls := p.nsStack[i].decls
+		for j := len(decls) - 1; j >= 0; j-- {
+			if decls[j].uri != uri {
+				continue
+			}
+			// The declaration must not be shadowed by an inner
+			// redeclaration of the same prefix to a different URI.
+			if cur, bound := p.currentBinding(decls[j].prefix); bound && cur == uri {
+				return decls[j].prefix, true
+			}
+		}
 	}
+	return "", false
+}
 
-	name := p.Name
-	space := p.Space
-
-	// Need to set the "current" token name/event
-	// to the previous StartTag event's name
-	p.resetTokenState()
-	p.Event = EndTag
-	p.Depth--
-
-	// decoder.DecodeElement consumed this element's end token internally, so
-	// processEndToken never ran for it. Pop the namespace scope its start token
-	// pushed, mirroring processEndToken, otherwise p.Spaces/SpacesStack desync
-	// and the stack grows one entry per DecodeElement call.
-	if len(p.SpacesStack) > 0 {
-		p.SpacesStack = p.SpacesStack[:len(p.SpacesStack)-1]
+func (p *Parser) currentBinding(prefix string) (string, bool) {
+	if n := len(p.nsStack); n > 0 {
+		uri, ok := p.nsStack[n-1].bindings[prefix]
+		return uri, ok
 	}
-	if len(p.SpacesStack) == 0 {
-		p.Spaces = map[string]string{}
-	} else {
-		p.Spaces = p.SpacesStack[len(p.SpacesStack)-1]
+	return "", false
+}
+
+// BaseURL returns the xml:base in scope for the current element, or nil when
+// none is declared. Nested xml:base values resolve against their parent per
+// RFC 3986. An unparseable xml:base is treated as absent (the element
+// inherits its parent's base). Resolving document URLs against the base is
+// the caller's concern.
+func (p *Parser) BaseURL() *url.URL {
+	if n := len(p.baseStack); n > 0 {
+		return p.baseStack[n-1]
 	}
-
-	p.Name = name
-	p.Space = space
-	p.token = nil
-
-	// decoder.DecodeElement consumed this element's end token internally, so
-	// processEndToken never ran for it. Pop the base its start token pushed
-	// (pushBase pushes one per element), mirroring processEndToken. Callers that
-	// need the element's xml:base to resolve relative URLs in `v` must capture
-	// it before calling DecodeElement.
-	p.popBase()
 	return nil
 }
 
-func (p *XMLPullParser) IsWhitespace() bool {
-	return strings.TrimSpace(p.Text) == ""
-}
-
-func (p *XMLPullParser) EventName(e XMLEventType) (name string) {
-	switch e {
-	case StartTag:
-		name = "StartTag"
-	case EndTag:
-		name = "EndTag"
-	case StartDocument:
-		name = "StartDocument"
-	case EndDocument:
-		name = "EndDocument"
-	case ProcessingInstruction:
-		name = "ProcessingInstruction"
-	case Directive:
-		name = "Directive"
-	case Comment:
-		name = "Comment"
-	case Text:
-		name = "Text"
-	case IgnorableWhitespace:
-		name = "IgnorableWhitespace"
-	}
-	return
-}
-
-func (p *XMLPullParser) EventType(t xml.Token) (event XMLEventType) {
-	switch t.(type) {
-	case xml.StartElement:
-		event = StartTag
-	case xml.EndElement:
-		event = EndTag
-	case xml.CharData:
-		event = Text
-	case xml.Comment:
-		event = Comment
-	case xml.ProcInst:
-		event = ProcessingInstruction
-	case xml.Directive:
-		event = Directive
-	}
-	return
-}
-
-// resolve the given string as a URL relative to current xml:base
-func (p *XMLPullParser) XmlBaseResolveUrl(u string) (*url.URL, error) {
-	curr := p.BaseStack.Top()
-	if curr == nil {
-		return nil, nil
-	}
-
-	relURL, err := url.Parse(u)
-	if err != nil {
-		return nil, err
-	}
-	// Work on a copy: curr is the live base held on the stack, so appending "/"
-	// to it would rewrite the base for every sibling resolved after the first
-	// relative URL in this scope.
-	base := *curr
-	if base.Path != "" && u != "" && base.Path[len(base.Path)-1] != '/' {
-		// There's no reason someone would use a path in xml:base if they
-		// didn't mean for it to be a directory
-		base.Path = base.Path + "/"
-	}
-	absURL := base.ResolveReference(relURL)
-	return absURL, nil
-}
-
-func (p *XMLPullParser) processToken(t xml.Token) {
+func (p *Parser) processToken(t xml.Token) {
 	switch tt := t.(type) {
 	case xml.StartElement:
-		p.processStartToken(tt)
+		p.depth++
+		p.attrs = tt.Attr
+		p.name = tt.Name.Local
+		p.space = tt.Name.Space
+		p.event = StartTag
+		p.pushNamespaces(tt)
+		p.pushBase()
 	case xml.EndElement:
-		p.processEndToken(tt)
+		p.name = tt.Name.Local
+		p.space = tt.Name.Space
+		p.event = EndTag
+		p.pendingPop = true
 	case xml.CharData:
-		p.processCharDataToken(tt)
+		p.text = string(tt)
+		p.event = Text
 	case xml.Comment:
-		p.processCommentToken(tt)
+		p.text = string(tt)
+		p.event = Comment
 	case xml.ProcInst:
-		p.processProcInstToken(tt)
+		p.text = fmt.Sprintf("%s %s", tt.Target, string(tt.Inst))
+		p.event = ProcessingInstruction
 	case xml.Directive:
-		p.processDirectiveToken(tt)
+		p.text = string(tt)
+		p.event = Directive
 	}
 }
 
-func (p *XMLPullParser) processStartToken(t xml.StartElement) {
-	p.Depth++
-	p.Attrs = t.Attr
-	p.Name = t.Name.Local
-	p.Space = t.Name.Space
-	p.trackNamespaces(t)
-	p.pushBase()
-}
-
-func (p *XMLPullParser) processEndToken(t xml.EndElement) {
-	p.Depth--
-	// Guard the pop: an end tag without a tracked start (possible only if
-	// internal invariants were violated) must not panic.
-	if len(p.SpacesStack) > 0 {
-		p.SpacesStack = p.SpacesStack[:len(p.SpacesStack)-1]
+func (p *Parser) applyPendingPop() {
+	if !p.pendingPop {
+		return
 	}
-	if len(p.SpacesStack) == 0 {
-		p.Spaces = map[string]string{}
-	} else {
-		p.Spaces = p.SpacesStack[len(p.SpacesStack)-1]
+	p.pendingPop = false
+	p.depth--
+	if n := len(p.nsStack); n > 0 {
+		p.nsStack = p.nsStack[:n-1]
 	}
-	p.Name = t.Name.Local
-	p.Space = t.Name.Space
-	p.popBase()
-}
-
-func (p *XMLPullParser) processCharDataToken(t xml.CharData) {
-	p.Text = string([]byte(t))
-}
-
-func (p *XMLPullParser) processCommentToken(t xml.Comment) {
-	p.Text = string([]byte(t))
-}
-
-func (p *XMLPullParser) processProcInstToken(t xml.ProcInst) {
-	p.Text = fmt.Sprintf("%s %s", t.Target, string(t.Inst))
-}
-
-func (p *XMLPullParser) processDirectiveToken(t xml.Directive) {
-	p.Text = string([]byte(t))
-}
-
-func (p *XMLPullParser) resetTokenState() {
-	p.Attrs = nil
-	p.Name = ""
-	p.Space = ""
-	p.Text = ""
-}
-
-func (p *XMLPullParser) trackNamespaces(t xml.StartElement) {
-	newSpace := map[string]string{}
-	for k, v := range p.Spaces {
-		newSpace[k] = v
+	if n := len(p.baseStack); n > 0 {
+		p.baseStack = p.baseStack[:n-1]
 	}
-	for _, attr := range t.Attr {
-		if attr.Name.Space == "xmlns" {
-			space := strings.TrimSpace(attr.Value)
-			spacePrefix := strings.TrimSpace(strings.ToLower(attr.Name.Local))
-			newSpace[space] = spacePrefix
-		} else if attr.Name.Local == "xmlns" {
-			space := strings.TrimSpace(attr.Value)
-			newSpace[space] = ""
+}
+
+func (p *Parser) resetTokenState() {
+	p.attrs = nil
+	p.name = ""
+	p.space = ""
+	p.text = ""
+}
+
+func (p *Parser) pushNamespaces(t xml.StartElement) {
+	merged := map[string]string{}
+	if n := len(p.nsStack); n > 0 {
+		for k, v := range p.nsStack[n-1].bindings {
+			merged[k] = v
 		}
 	}
-	p.Spaces = newSpace
-	p.SpacesStack = append(p.SpacesStack, newSpace)
-}
-
-// returns the popped base URL
-func (p *XMLPullParser) popBase() string {
-	url := p.BaseStack.pop()
-	if url != nil {
-		return url.String()
+	var decls []nsDecl
+	for _, attr := range t.Attr {
+		switch {
+		case attr.Name.Space == "xmlns":
+			d := nsDecl{prefix: attr.Name.Local, uri: strings.TrimSpace(attr.Value)}
+			merged[d.prefix] = d.uri
+			decls = append(decls, d)
+		case attr.Name.Space == "" && attr.Name.Local == "xmlns":
+			d := nsDecl{prefix: "", uri: strings.TrimSpace(attr.Value)}
+			merged[d.prefix] = d.uri
+			decls = append(decls, d)
+		}
 	}
-	return ""
+	p.nsStack = append(p.nsStack, nsScope{bindings: merged, decls: decls})
 }
 
-// Searches current attributes for xml:base and updates the urlStack
-func (p *XMLPullParser) pushBase() error {
-	// Push a base entry for every element so the stack stays balanced with the
-	// per-element pop in processEndToken and DecodeElement. An element with its
-	// own xml:base resolves it against the parent's base; otherwise it inherits
-	// the parent's base unchanged. Pushing conditionally (only for xml:base
-	// elements) while popping unconditionally would pop an ancestor's base when
-	// a plain element closes.
-	parent := p.BaseStack.Top()
+func (p *Parser) pushBase() {
+	var parent *url.URL
+	if n := len(p.baseStack); n > 0 {
+		parent = p.baseStack[n-1]
+	}
 
-	var base string
-	for _, attr := range p.Attrs {
+	var raw string
+	for _, attr := range p.attrs {
 		if attr.Name.Local == "base" && attr.Name.Space == xmlNSURI {
-			base = attr.Value
+			raw = attr.Value
 			break
 		}
 	}
-
-	if base == "" {
-		p.BaseStack.push(parent)
-		return nil
+	if raw == "" {
+		p.baseStack = append(p.baseStack, parent)
+		return
 	}
-
-	newURL, err := url.Parse(base)
+	u, err := url.Parse(raw)
 	if err != nil {
-		// Still push so the stack stays balanced with the matching pop.
-		p.BaseStack.push(parent)
-		return err
+		// An unparseable xml:base is treated as absent; the element
+		// inherits its parent's base.
+		p.baseStack = append(p.baseStack, parent)
+		return
 	}
 	if parent != nil {
-		newURL = parent.ResolveReference(newURL)
+		u = parent.ResolveReference(u)
 	}
-	p.BaseStack.push(newURL)
-	return nil
+	p.baseStack = append(p.baseStack, u)
+}
+
+func (p *Parser) expectErr(event EventType, space, name string) *ExpectError {
+	return &ExpectError{
+		WantEvent: event, WantSpace: space, WantName: name,
+		GotEvent: p.event, GotSpace: p.space, GotName: p.name,
+		Offset: p.InputOffset(),
+	}
 }

--- a/xpp_test.go
+++ b/xpp_test.go
@@ -2,437 +2,167 @@ package xpp_test
 
 import (
 	"bytes"
+	"encoding/xml"
+	"errors"
 	"io"
-	"reflect"
+	"strings"
 	"testing"
 
-	xpp "github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp/v2"
 )
 
-// Small assertion helpers so this package has no test dependencies.
+func newParser(doc string) *xpp.Parser {
+	d := xml.NewDecoder(bytes.NewReader([]byte(doc)))
+	d.Strict = false
+	return xpp.New(d)
+}
 
-func eq(t *testing.T, got, want interface{}) {
+// advanceTo positions the parser on the first StartTag with the given local
+// name.
+func advanceTo(t *testing.T, p *xpp.Parser, name string) {
 	t.Helper()
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("not equal:\n  got:  %#v\n  want: %#v", got, want)
-	}
-}
-
-func noErr(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func hasErr(t *testing.T, err error) {
-	t.Helper()
-	if err == nil {
-		t.Error("expected an error, got nil")
-	}
-}
-
-func lenIs(t *testing.T, got, want int) {
-	t.Helper()
-	if got != want {
-		t.Errorf("length = %d, want %d", got, want)
-	}
-}
-
-func TestEventName(t *testing.T) {
-	var eventNameTests = []struct {
-		event    xpp.XMLEventType
-		expected string
-	}{
-		{xpp.StartTag, "StartTag"},
-		{xpp.EndTag, "EndTag"},
-		{xpp.StartDocument, "StartDocument"},
-		{xpp.EndDocument, "EndDocument"},
-		{xpp.ProcessingInstruction, "ProcessingInstruction"},
-		{xpp.Directive, "Directive"},
-		{xpp.Comment, "Comment"},
-		{xpp.Text, "Text"},
-		{xpp.IgnorableWhitespace, "IgnorableWhitespace"},
-	}
-
-	p := xpp.XMLPullParser{}
-	for _, test := range eventNameTests {
-		actual := p.EventName(test.event)
-		eq(t, actual, test.expected)
-	}
-}
-
-func TestSpaceStackSelfClosingTag(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	r := bytes.NewBufferString(`<a:y xmlns:a="z"/><x>foo</x>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-	toNextStart(t, p)
-	eq(t, p.Spaces, map[string]string{"z": "a"})
-	toNextStart(t, p)
-	eq(t, p.Spaces, map[string]string{})
-}
-
-func TestSpaceStackNestedTag(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	r := bytes.NewBufferString(`<y xmlns:a="z"><a:x>foo</a:x></y><w></w>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-	toNextStart(t, p)
-	eq(t, p.Spaces, map[string]string{"z": "a"})
-	toNextStart(t, p)
-	eq(t, p.Spaces, map[string]string{"z": "a"})
-	toNextStart(t, p)
-	eq(t, p.Spaces, map[string]string{})
-}
-
-func TestDecodeElementDepth(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	r := bytes.NewBufferString(`<root><d2>foo</d2><d2>bar</d2></root>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-
-	type v struct{}
-
-	// move to root
-	p.NextTag()
-	eq(t, p.Name, "root")
-	eq(t, p.Depth, 1)
-
-	// decode first <d2>
-	p.NextTag()
-	eq(t, p.Name, "d2")
-	eq(t, p.Depth, 2)
-	p.DecodeElement(&v{})
-
-	// decode second <d2>
-	p.NextTag()
-	eq(t, p.Name, "d2")
-	eq(t, p.Depth, 2) // should still be 2, not 3
-	p.DecodeElement(&v{})
-}
-
-func TestDecodeElementNamespaceStack(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	// The first <d2> declares its own namespace (b:w). After decoding it, that
-	// scope must be popped so the parser is back to root's namespaces.
-	r := bytes.NewBufferString(`<root xmlns:a="z"><d2 xmlns:b="w">foo</d2><d2>bar</d2></root>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-
-	type v struct{}
-
-	p.NextTag() // root
-	eq(t, p.Spaces, map[string]string{"z": "a"})
-	lenIs(t, len(p.SpacesStack), 1)
-
-	p.NextTag() // first <d2>, adds b:w
-	eq(t, p.Spaces, map[string]string{"z": "a", "w": "b"})
-	lenIs(t, len(p.SpacesStack), 2)
-
-	p.DecodeElement(&v{})
-	// Scope must be back to root's: b:w no longer leaks and the stack shrank.
-	eq(t, p.Spaces, map[string]string{"z": "a"})
-	lenIs(t, len(p.SpacesStack), 1)
-
-	p.NextTag() // second <d2>
-	eq(t, p.Spaces, map[string]string{"z": "a"})
-}
-
-func TestXMLBase(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	r := bytes.NewBufferString(`<root xml:base="https://example.org/path/"><d2 xml:base="relative">foo</d2><d2 xml:base="/absolute">bar</d2><d2>baz</d2></root>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-
-	type v struct{}
-
-	// move to root
-	p.NextTag()
-	eq(t, p.Name, "root")
-	eq(t, p.BaseStack.Top().String(), "https://example.org/path/")
-
-	// decode first <d2>
-	p.NextTag()
-	eq(t, p.Name, "d2")
-	eq(t, p.BaseStack.Top().String(), "https://example.org/path/relative")
-
-	resolved, err := p.XmlBaseResolveUrl("test")
-	noErr(t, err)
-	eq(t, resolved.String(), "https://example.org/path/relative/test")
-	p.DecodeElement(&v{})
-
-	// decode second <d2>
-	p.NextTag()
-	eq(t, p.Name, "d2")
-	eq(t, p.BaseStack.Top().String(), "https://example.org/absolute")
-	p.DecodeElement(&v{})
-
-	// ensure xml:base is still set to root element's base
-	p.NextTag()
-	eq(t, p.Name, "d2")
-	eq(t, p.BaseStack.Top().String(), "https://example.org/path/")
-}
-
-func TestXmlBaseResolveUrlDoesNotMutateBase(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	r := bytes.NewBufferString(`<root xml:base="https://example.org/a/b"><d/></root>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-
-	p.NextTag() // root, base is https://example.org/a/b
-	before := p.BaseStack.Top().String()
-
-	resolved, err := p.XmlBaseResolveUrl("x")
-	noErr(t, err)
-	eq(t, resolved.String(), "https://example.org/a/b/x")
-
-	// The stacked base must be unchanged by the resolution.
-	eq(t, p.BaseStack.Top().String(), before)
-}
-
-func TestXmlBaseSurvivesContainerClose(t *testing.T) {
-	crReader := func(charset string, input io.Reader) (io.Reader, error) {
-		return input, nil
-	}
-	// <child> has no xml:base of its own; closing it must not discard the root's
-	// base for the following <after>.
-	r := bytes.NewBufferString(`<root xml:base="http://example.org/a/"><child></child><after></after></root>`)
-	p := xpp.NewXMLPullParser(r, false, crReader)
-
-	p.NextTag() // <root>
-	p.NextTag() // <child>
-	p.NextTag() // </child>  (processEndToken pops a base)
-	p.NextTag() // <after>
-	eq(t, p.Name, "after")
-
-	got, err := p.XmlBaseResolveUrl("rel")
-	noErr(t, err)
-	if got == nil || got.String() != "http://example.org/a/rel" {
-		t.Errorf("resolved = %v, want http://example.org/a/rel", got)
-	}
-}
-
-func toNextStart(t *testing.T, p *xpp.XMLPullParser) {
 	for {
 		tok, err := p.NextToken()
 		if err != nil {
-			t.Error(err)
-			t.FailNow()
+			t.Fatalf("advanceTo(%s): %v", name, err)
 		}
-		if tok == xpp.StartTag {
+		if tok == xpp.StartTag && p.Name() == name {
+			return
+		}
+		if tok == xpp.EndDocument {
+			t.Fatalf("advanceTo(%s): document ended", name)
+		}
+	}
+}
+
+func TestEventTypeString(t *testing.T) {
+	cases := map[xpp.EventType]string{
+		xpp.StartDocument:         "StartDocument",
+		xpp.EndDocument:           "EndDocument",
+		xpp.StartTag:              "StartTag",
+		xpp.EndTag:                "EndTag",
+		xpp.Text:                  "Text",
+		xpp.Comment:               "Comment",
+		xpp.ProcessingInstruction: "ProcessingInstruction",
+		xpp.Directive:             "Directive",
+		xpp.EventType(99):         "EventType(99)",
+	}
+	for e, want := range cases {
+		if got := e.String(); got != want {
+			t.Errorf("String(%d) = %q, want %q", int(e), got, want)
+		}
+	}
+}
+
+func TestTokenWalk(t *testing.T) {
+	p := newParser(`<?xml version="1.0"?><!-- c --><root a="1"><child>hi</child></root>`)
+
+	if p.Event() != xpp.StartDocument {
+		t.Fatalf("initial event = %v, want StartDocument", p.Event())
+	}
+
+	type step struct {
+		event xpp.EventType
+		name  string
+		text  string
+	}
+	want := []step{
+		{xpp.ProcessingInstruction, "", ""},
+		{xpp.Comment, "", " c "},
+		{xpp.StartTag, "root", ""},
+		{xpp.StartTag, "child", ""},
+		{xpp.Text, "", "hi"},
+		{xpp.EndTag, "child", ""},
+		{xpp.EndTag, "root", ""},
+		{xpp.EndDocument, "", ""},
+	}
+	for i, w := range want {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatalf("step %d: %v", i, err)
+		}
+		if tok != w.event || p.Event() != w.event {
+			t.Fatalf("step %d: event = %v, want %v", i, tok, w.event)
+		}
+		if w.name != "" && p.Name() != w.name {
+			t.Fatalf("step %d: name = %q, want %q", i, p.Name(), w.name)
+		}
+		if w.text != "" && p.Text() != w.text {
+			t.Fatalf("step %d: text = %q, want %q", i, p.Text(), w.text)
+		}
+	}
+}
+
+func TestNextSkipsNonContent(t *testing.T) {
+	p := newParser(`<?xml version="1.0"?><!-- c --><root><!-- inner -->x</root>`)
+
+	tok, err := p.Next()
+	if err != nil || tok != xpp.StartTag || p.Name() != "root" {
+		t.Fatalf("Next = %v %q (%v), want StartTag root", tok, p.Name(), err)
+	}
+	tok, err = p.Next()
+	if err != nil || tok != xpp.Text || p.Text() != "x" {
+		t.Fatalf("Next = %v %q (%v), want Text x", tok, p.Text(), err)
+	}
+}
+
+func TestEOFAfterEndDocument(t *testing.T) {
+	p := newParser(`<root/>`)
+	sawEnd := false
+	for i := 0; i < 10; i++ {
+		tok, err := p.NextToken()
+		if !sawEnd {
+			if err != nil {
+				t.Fatalf("call %d: unexpected error %v", i, err)
+			}
+			if tok == xpp.EndDocument {
+				sawEnd = true
+			}
+			continue
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("call %d after EndDocument: err = %v, want io.EOF", i, err)
+		}
+		if tok != xpp.EndDocument {
+			t.Fatalf("call %d after EndDocument: event = %v, want EndDocument", i, tok)
+		}
+	}
+	if !sawEnd {
+		t.Fatal("never saw EndDocument")
+	}
+	if p.Err() != nil {
+		t.Fatalf("Err() after clean EOF = %v, want nil", p.Err())
+	}
+}
+
+func TestSyntaxErrorPoisonsAndIsMatchable(t *testing.T) {
+	p := newParser(`<root><unclosed>`)
+	var last error
+	for i := 0; i < 10; i++ {
+		if _, err := p.NextToken(); err != nil {
+			last = err
 			break
 		}
 	}
-}
-
-func TestNextText(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-		wantErr  bool
-	}{
-		{
-			name:     "simple text",
-			input:    "<root>simple text</root>",
-			expected: "simple text",
-			wantErr:  false,
-		},
-		{
-			name:     "empty text",
-			input:    "<root></root>",
-			expected: "",
-			wantErr:  false,
-		},
-		{
-			name:     "mixed content",
-			input:    "<root>text<child/>text2</root>",
-			expected: "",
-			wantErr:  true,
-		},
-		{
-			name:     "whitespace text",
-			input:    "<root>  \t\n  </root>",
-			expected: "  \t\n  ",
-			wantErr:  false,
-		},
+	if last == nil {
+		t.Fatal("truncated document produced no error")
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := xpp.NewXMLPullParser(bytes.NewBufferString(tt.input), true, nil)
-
-			// Move to first start tag
-			_, err := p.NextTag()
-			noErr(t, err)
-
-			result, err := p.NextText()
-			if tt.wantErr {
-				hasErr(t, err)
-				return
-			}
-
-			noErr(t, err)
-			eq(t, result, tt.expected)
-		})
+	var serr *xml.SyntaxError
+	if !errors.As(last, &serr) {
+		t.Fatalf("error %v is not matchable as *xml.SyntaxError", last)
+	}
+	if p.Err() == nil {
+		t.Fatal("Err() should be sticky after a decoder error")
+	}
+	if _, err := p.NextToken(); err == nil {
+		t.Fatal("NextToken after decoder error should keep failing")
 	}
 }
 
-func TestSkip(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		wantErr bool
-	}{
-		{
-			name: "skip simple element",
-			input: `<root>
-						<skip>content to skip</skip>
-						<keep>content to keep</keep>
-					</root>`,
-			wantErr: false,
-		},
-		{
-			name: "skip nested elements",
-			input: `<root>
-						<skip>
-							<child1>skip this</child1>
-							<child2>and this</child2>
-						</skip>
-						<keep>content to keep</keep>
-					</root>`,
-			wantErr: false,
-		},
-		{
-			name: "skip with attributes",
-			input: `<root>
-						<skip attr="value">
-							<child attr2="value2">skip this</child>
-						</skip>
-						<keep>content to keep</keep>
-					</root>`,
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := xpp.NewXMLPullParser(bytes.NewBufferString(tt.input), true, nil)
-
-			// Move to root
-			_, err := p.NextTag()
-			noErr(t, err)
-
-			// Move to skip element
-			_, err = p.NextTag()
-			noErr(t, err)
-
-			// Skip the element
-			err = p.Skip()
-			if tt.wantErr {
-				hasErr(t, err)
-				return
-			}
-			noErr(t, err)
-
-			// Verify we're at the keep element
-			_, err = p.NextTag()
-			noErr(t, err)
-			eq(t, p.Name, "keep")
-		})
-	}
-}
-
-func TestSpecialCases(t *testing.T) {
-	tests := []struct {
-		name          string
-		input         string
-		expectedTypes []xpp.XMLEventType
-	}{
-		{
-			name:  "processing instruction",
-			input: `<?target data?><root/>`,
-			expectedTypes: []xpp.XMLEventType{
-				xpp.ProcessingInstruction,
-				xpp.StartTag,
-				xpp.EndTag,
-				xpp.EndDocument,
-			},
-		},
-		{
-			name:  "comments",
-			input: `<!-- comment --><root/>`,
-			expectedTypes: []xpp.XMLEventType{
-				xpp.Comment,
-				xpp.StartTag,
-				xpp.EndTag,
-				xpp.EndDocument,
-			},
-		},
-		{
-			name:  "mixed content",
-			input: `<root>text<child/>text</root>`,
-			expectedTypes: []xpp.XMLEventType{
-				xpp.StartTag,
-				xpp.Text,
-				xpp.StartTag,
-				xpp.EndTag,
-				xpp.Text,
-				xpp.EndTag,
-				xpp.EndDocument,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Logf("Starting test case: %s with input: %s", tt.name, tt.input)
-			p := xpp.NewXMLPullParser(bytes.NewBufferString(tt.input), true, nil)
-
-			var events []xpp.XMLEventType
-			for {
-				event, err := p.NextToken()
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				events = append(events, event)
-				t.Logf("Event: %s (Name: %s, Text: %q)", p.EventName(event), p.Name, p.Text)
-
-				// Stop when we reach EndDocument
-				if event == xpp.EndDocument {
-					break
-				}
-			}
-
-			eq(t, events, tt.expectedTypes)
-		})
-	}
-}
-
-// A DecodeElement unmarshal error leaves the decoder mid-element. The parser
-// must refuse to continue rather than run with desynced stacks, which used to
-// end in a slice-bounds panic at the enclosing end tags (issue #28).
 func TestDecodeElementErrorPoisonsParser(t *testing.T) {
 	doc := `<root><d2><inner><n>notanumber</n><m>y</m></inner></d2><d3/></root>`
-	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
-
-	// Position on <d2>.
-	for {
-		tok, err := p.NextToken()
-		if err != nil {
-			t.Fatalf("setup: %v", err)
-		}
-		if tok == xpp.StartTag && p.Name == "d2" {
-			break
-		}
-	}
+	p := newParser(doc)
+	advanceTo(t, p, "d2")
 
 	var v struct {
 		Inner struct {
@@ -442,40 +172,27 @@ func TestDecodeElementErrorPoisonsParser(t *testing.T) {
 	if err := p.DecodeElement(&v); err == nil {
 		t.Fatal("DecodeElement should fail on notanumber -> int")
 	}
-
-	// Every subsequent call must return an error; pulling tokens through the
-	// rest of the document must not panic at </d2> or </root>.
+	if p.Err() == nil {
+		t.Fatal("Err() should be set after failed DecodeElement")
+	}
 	for i := 0; i < 20; i++ {
 		if _, err := p.NextToken(); err == nil {
 			t.Fatalf("NextToken call %d after failed DecodeElement should error", i)
 		}
 	}
-	if _, err := p.Next(); err == nil {
-		t.Fatal("Next after failed DecodeElement should error")
-	}
 	if _, err := p.NextTag(); err == nil {
 		t.Fatal("NextTag after failed DecodeElement should error")
 	}
-	if err := p.Skip(); err == nil {
-		t.Fatal("Skip after failed DecodeElement should error")
+	if err := p.DecodeElement(&v); err == nil {
+		t.Fatal("DecodeElement after poison should error")
 	}
 }
 
-// A successful DecodeElement must not set the sticky error; the parser
-// continues normally.
-func TestDecodeElementSuccessDoesNotPoison(t *testing.T) {
-	doc := `<root><d2><n>42</n></d2><d3>x</d3></root>`
-	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
-
-	for {
-		tok, err := p.NextToken()
-		if err != nil {
-			t.Fatalf("setup: %v", err)
-		}
-		if tok == xpp.StartTag && p.Name == "d2" {
-			break
-		}
-	}
+func TestDecodeElementSuccess(t *testing.T) {
+	doc := `<root xmlns:a="http://ns"><a:x><n>42</n></a:x><d3>y</d3></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "x")
+	startDepth := p.Depth()
 
 	var v struct {
 		N int `xml:"n"`
@@ -486,93 +203,409 @@ func TestDecodeElementSuccessDoesNotPoison(t *testing.T) {
 	if v.N != 42 {
 		t.Fatalf("N = %d, want 42", v.N)
 	}
+	if p.Event() != xpp.EndTag || p.Name() != "x" || p.Space() != "http://ns" {
+		t.Fatalf("cursor = %v %q space %q, want EndTag x http://ns", p.Event(), p.Name(), p.Space())
+	}
+	if p.Depth() != startDepth {
+		t.Fatalf("Depth on synthetic EndTag = %d, want %d", p.Depth(), startDepth)
+	}
+	if p.Err() != nil {
+		t.Fatalf("Err() after successful DecodeElement = %v", p.Err())
+	}
 
 	tok, err := p.NextTag()
-	if err != nil {
-		t.Fatalf("NextTag after successful DecodeElement: %v", err)
-	}
-	if tok != xpp.StartTag || p.Name != "d3" {
-		t.Fatalf("got %s %q, want StartTag d3", p.EventName(tok), p.Name)
+	if err != nil || tok != xpp.StartTag || p.Name() != "d3" {
+		t.Fatalf("NextTag = %v %q (%v), want StartTag d3", tok, p.Name(), err)
 	}
 }
 
-// EndTag events must carry the element's namespace so ExpectAll can validate
-// end tags (issue #29).
-func TestEndTagSpacePopulated(t *testing.T) {
-	doc := `<a:x xmlns:a="http://ns">v</a:x>`
-	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+func TestDecodeElementPrecondition(t *testing.T) {
+	p := newParser(`<root>text</root>`)
+	advanceTo(t, p, "root")
+	if _, err := p.Next(); err != nil { // on Text
+		t.Fatal(err)
+	}
+	var v struct{}
+	err := p.DecodeElement(&v)
+	var ee *xpp.ExpectError
+	if !errors.As(err, &ee) {
+		t.Fatalf("err = %v, want *ExpectError", err)
+	}
+	if ee.WantEvent != xpp.StartTag || ee.GotEvent != xpp.Text {
+		t.Fatalf("ExpectError = %+v, want StartTag/Text", ee)
+	}
+}
 
+func TestDepthEndTagMatchesStartTag(t *testing.T) {
+	p := newParser(`<a><b><c/></b></a>`)
+	depths := map[string][2]int{} // name -> [start, end]
 	for {
 		tok, err := p.NextToken()
 		if err != nil {
-			t.Fatalf("next: %v", err)
+			t.Fatal(err)
+		}
+		if tok == xpp.StartTag {
+			d := depths[p.Name()]
+			d[0] = p.Depth()
+			depths[p.Name()] = d
 		}
 		if tok == xpp.EndTag {
-			break
+			d := depths[p.Name()]
+			d[1] = p.Depth()
+			depths[p.Name()] = d
 		}
 		if tok == xpp.EndDocument {
-			t.Fatal("no end tag seen")
+			break
 		}
 	}
-
-	if p.Space != "http://ns" {
-		t.Fatalf("Space on EndTag = %q, want %q", p.Space, "http://ns")
-	}
-	if err := p.ExpectAll(xpp.EndTag, "http://ns", "x"); err != nil {
-		t.Fatalf("ExpectAll on end tag: %v", err)
+	want := map[string][2]int{"a": {1, 1}, "b": {2, 2}, "c": {3, 3}}
+	for name, w := range want {
+		if depths[name] != w {
+			t.Errorf("depths[%s] = %v, want %v", name, depths[name], w)
+		}
 	}
 }
 
-// The synthetic EndTag left behind by DecodeElement must carry the decoded
-// element's namespace too.
-func TestDecodeElementEndTagSpace(t *testing.T) {
-	doc := `<root xmlns:a="http://ns"><a:x><n>1</n></a:x></root>`
-	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+func TestNamespaces(t *testing.T) {
+	doc := `<root xmlns:DC="http://purl.org/dc" xmlns="http://default"><DC:title/></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "title")
 
-	for {
-		tok, err := p.NextToken()
-		if err != nil {
-			t.Fatalf("next: %v", err)
-		}
-		if tok == xpp.StartTag && p.Name == "x" {
-			break
-		}
+	ns := p.Namespaces()
+	if ns["DC"] != "http://purl.org/dc" {
+		t.Fatalf("Namespaces()[DC] = %q, want the URI with prefix case preserved", ns["DC"])
 	}
+	if ns[""] != "http://default" {
+		t.Fatalf("default namespace = %q, want http://default", ns[""])
+	}
+
+	// Snapshot: mutating the returned map must not affect the parser.
+	ns["DC"] = "corrupted"
+	if got := p.Namespaces()["DC"]; got != "http://purl.org/dc" {
+		t.Fatalf("parser bindings mutated through snapshot: %q", got)
+	}
+}
+
+func TestDuplicateBindingsNotLossy(t *testing.T) {
+	doc := `<root xmlns:a="http://ns" xmlns:b="http://ns"><a:x/></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "x")
+
+	ns := p.Namespaces()
+	if ns["a"] != "http://ns" || ns["b"] != "http://ns" {
+		t.Fatalf("both prefixes must be bound: %v", ns)
+	}
+	// Most recently declared prefix wins the reverse lookup.
+	prefix, ok := p.PrefixForURI("http://ns")
+	if !ok || prefix != "b" {
+		t.Fatalf("PrefixForURI = %q %v, want b true", prefix, ok)
+	}
+}
+
+func TestPrefixForURI(t *testing.T) {
+	doc := `<root xmlns:out="http://u1"><mid xmlns:in="http://u1"><leaf/></mid></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "leaf")
+
+	// Innermost declaration wins.
+	prefix, ok := p.PrefixForURI("http://u1")
+	if !ok || prefix != "in" {
+		t.Fatalf("PrefixForURI = %q %v, want in true", prefix, ok)
+	}
+	if _, ok := p.PrefixForURI("http://unbound"); ok {
+		t.Fatal("PrefixForURI for unbound URI should report ok=false")
+	}
+	// Whitespace in the query is tolerated, matching declaration trimming.
+	if prefix, ok := p.PrefixForURI(" http://u1 "); !ok || prefix != "in" {
+		t.Fatalf("trimmed lookup = %q %v, want in true", prefix, ok)
+	}
+}
+
+func TestPrefixForURIShadowed(t *testing.T) {
+	// Prefix a is rebound to a different URI in the inner scope, so it is
+	// no longer an in-scope prefix for the outer URI.
+	doc := `<root xmlns:a="http://u1"><mid xmlns:a="http://u2"><leaf/></mid></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "leaf")
+
+	if _, ok := p.PrefixForURI("http://u1"); ok {
+		t.Fatal("shadowed binding should not be returned")
+	}
+	if prefix, ok := p.PrefixForURI("http://u2"); !ok || prefix != "a" {
+		t.Fatalf("PrefixForURI(u2) = %q %v, want a true", prefix, ok)
+	}
+}
+
+func TestBaseURLNestedResolution(t *testing.T) {
+	// A file-like base must resolve per RFC 3986: the last path segment is
+	// replaced, not treated as a directory.
+	doc := `<root xml:base="http://example.org/dir/file.xml"><mid xml:base="other/"><leaf/></mid></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "leaf")
+
+	base := p.BaseURL()
+	if base == nil {
+		t.Fatal("BaseURL = nil")
+	}
+	if got := base.String(); got != "http://example.org/dir/other/" {
+		t.Fatalf("BaseURL = %q, want http://example.org/dir/other/", got)
+	}
+}
+
+func TestBaseURLScopes(t *testing.T) {
+	doc := `<root xml:base="http://a/"><mid xml:base="http://b/"><leaf/></mid><sib/></root>`
+	p := newParser(doc)
+
+	advanceTo(t, p, "leaf")
+	if got := p.BaseURL().String(); got != "http://b/" {
+		t.Fatalf("leaf base = %q, want http://b/", got)
+	}
+
+	// On mid's end tag, the base still describes mid.
+	if _, err := p.NextToken(); err != nil { // </leaf>
+		t.Fatal(err)
+	}
+	if _, err := p.NextToken(); err != nil { // </mid>
+		t.Fatal(err)
+	}
+	if p.Event() != xpp.EndTag || p.Name() != "mid" {
+		t.Fatalf("cursor = %v %q, want EndTag mid", p.Event(), p.Name())
+	}
+	if got := p.BaseURL().String(); got != "http://b/" {
+		t.Fatalf("base on </mid> = %q, want http://b/", got)
+	}
+
+	// On the sibling, the scope has popped back to root's base.
+	advanceTo(t, p, "sib")
+	if got := p.BaseURL().String(); got != "http://a/" {
+		t.Fatalf("sib base = %q, want http://a/", got)
+	}
+}
+
+func TestBaseURLAfterDecodeElement(t *testing.T) {
+	doc := `<root xml:base="http://a/"><item xml:base="sub/"><n>1</n></item><next/></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "item")
 
 	var v struct {
 		N int `xml:"n"`
 	}
 	if err := p.DecodeElement(&v); err != nil {
-		t.Fatalf("DecodeElement: %v", err)
+		t.Fatal(err)
 	}
-	if err := p.ExpectAll(xpp.EndTag, "http://ns", "x"); err != nil {
-		t.Fatalf("ExpectAll on synthetic end tag: %v", err)
+	// The cursor sits on item's end tag; the base still describes item.
+	if got := p.BaseURL().String(); got != "http://a/sub/" {
+		t.Fatalf("base after DecodeElement = %q, want http://a/sub/", got)
+	}
+	advanceTo(t, p, "next")
+	if got := p.BaseURL().String(); got != "http://a/" {
+		t.Fatalf("base on sibling = %q, want http://a/", got)
 	}
 }
 
-// A foreign-namespaced attribute must not shadow the plain attribute with
-// the same local name (issue #31).
-func TestAttributePrefersUnNamespaced(t *testing.T) {
-	doc := `<root xmlns:o="http://other" o:href="WRONG" href="right"/>`
-	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
-
-	if _, err := p.NextTag(); err != nil {
-		t.Fatalf("next: %v", err)
+func TestBaseURLUnparseableInherits(t *testing.T) {
+	doc := "<root xml:base=\"http://a/\"><mid xml:base=\"http://bad url\x7f::\"><leaf/></mid></root>"
+	p := newParser(doc)
+	advanceTo(t, p, "leaf")
+	base := p.BaseURL()
+	if base == nil || base.String() != "http://a/" {
+		t.Fatalf("base = %v, want inherited http://a/", base)
 	}
+}
+
+func TestBaseURLAbsent(t *testing.T) {
+	p := newParser(`<root><leaf/></root>`)
+	advanceTo(t, p, "leaf")
+	if p.BaseURL() != nil {
+		t.Fatalf("BaseURL = %v, want nil", p.BaseURL())
+	}
+}
+
+func TestExpect(t *testing.T) {
+	doc := `<a:Root xmlns:a="http://NS">v</a:Root>`
+	p := newParser(doc)
+	advanceTo(t, p, "Root")
+
+	// Case-insensitive name and space, wildcard forms.
+	if err := p.Expect(xpp.StartTag, "root"); err != nil {
+		t.Fatalf("Expect fold: %v", err)
+	}
+	if err := p.ExpectAll(xpp.StartTag, "http://ns", "ROOT"); err != nil {
+		t.Fatalf("ExpectAll fold: %v", err)
+	}
+	if err := p.ExpectAll(xpp.StartTag, "*", "*"); err != nil {
+		t.Fatalf("ExpectAll wildcard: %v", err)
+	}
+
+	err := p.Expect(xpp.EndTag, "root")
+	var ee *xpp.ExpectError
+	if !errors.As(err, &ee) {
+		t.Fatalf("err = %v, want *ExpectError", err)
+	}
+	if ee.WantEvent != xpp.EndTag || ee.GotEvent != xpp.StartTag || ee.GotName != "Root" {
+		t.Fatalf("ExpectError fields = %+v", ee)
+	}
+	if !strings.Contains(err.Error(), "EndTag") || !strings.Contains(err.Error(), "StartTag") {
+		t.Fatalf("Error() = %q, should mention both events", err.Error())
+	}
+
+	// End-tag namespace validation works (Space is populated on EndTag).
+	if _, err := p.Next(); err != nil { // Text
+		t.Fatal(err)
+	}
+	if _, err := p.Next(); err != nil { // EndTag
+		t.Fatal(err)
+	}
+	if err := p.ExpectAll(xpp.EndTag, "http://ns", "root"); err != nil {
+		t.Fatalf("ExpectAll on end tag: %v", err)
+	}
+}
+
+func TestNextTag(t *testing.T) {
+	p := newParser("<root>\n  <child/>\n</root>")
+	advanceTo(t, p, "root")
+
+	tok, err := p.NextTag()
+	if err != nil || tok != xpp.StartTag || p.Name() != "child" {
+		t.Fatalf("NextTag = %v %q (%v), want StartTag child", tok, p.Name(), err)
+	}
+
+	p2 := newParser(`<root>real text</root>`)
+	advanceTo(t, p2, "root")
+	_, err = p2.NextTag()
+	var ee *xpp.ExpectError
+	if !errors.As(err, &ee) {
+		t.Fatalf("NextTag on text: err = %v, want *ExpectError", err)
+	}
+}
+
+func TestNextText(t *testing.T) {
+	p := newParser(`<root>a &amp; b<![CDATA[ & c]]></root>`)
+	advanceTo(t, p, "root")
+	text, err := p.NextText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "a & b & c" {
+		t.Fatalf("NextText = %q, want %q", text, "a & b & c")
+	}
+	if p.Event() != xpp.EndTag {
+		t.Fatalf("cursor after NextText = %v, want EndTag", p.Event())
+	}
+}
+
+func TestNextTextPreconditionAndMixedContent(t *testing.T) {
+	p := newParser(`<root>t</root>`)
+	if _, err := p.NextText(); err == nil {
+		t.Fatal("NextText before StartTag should error")
+	}
+
+	p2 := newParser(`<root>text<child/></root>`)
+	advanceTo(t, p2, "root")
+	_, err := p2.NextText()
+	var ee *xpp.ExpectError
+	if !errors.As(err, &ee) {
+		t.Fatalf("NextText on mixed content: err = %v, want *ExpectError", err)
+	}
+}
+
+func TestSkip(t *testing.T) {
+	doc := `<root><skipme><deep><deeper/></deep>text</skipme><after/></root>`
+	p := newParser(doc)
+	advanceTo(t, p, "skipme")
+
+	if err := p.Skip(); err != nil {
+		t.Fatal(err)
+	}
+	if p.Event() != xpp.EndTag || p.Name() != "skipme" {
+		t.Fatalf("cursor after Skip = %v %q, want EndTag skipme", p.Event(), p.Name())
+	}
+	tok, err := p.NextTag()
+	if err != nil || tok != xpp.StartTag || p.Name() != "after" {
+		t.Fatalf("after Skip: %v %q (%v), want StartTag after", tok, p.Name(), err)
+	}
+}
+
+func TestSkipPrecondition(t *testing.T) {
+	p := newParser(`<root><a/></root>`)
+	advanceTo(t, p, "a")
+	// Advance to </a>.
+	if _, err := p.NextToken(); err != nil {
+		t.Fatal(err)
+	}
+	err := p.Skip()
+	var ee *xpp.ExpectError
+	if !errors.As(err, &ee) {
+		t.Fatalf("Skip on EndTag: err = %v, want *ExpectError", err)
+	}
+	if ee.WantEvent != xpp.StartTag || ee.GotEvent != xpp.EndTag {
+		t.Fatalf("ExpectError fields = %+v", ee)
+	}
+}
+
+func TestAttributePreference(t *testing.T) {
+	doc := `<root xmlns:o="http://other" o:href="WRONG" href="right" o:only="fallback"/>`
+	p := newParser(doc)
+	advanceTo(t, p, "root")
+
 	if got := p.Attribute("href"); got != "right" {
-		t.Fatalf("Attribute(href) = %q, want %q", got, "right")
+		t.Fatalf("Attribute(href) = %q, want right", got)
+	}
+	if got := p.Attribute("only"); got != "fallback" {
+		t.Fatalf("Attribute(only) = %q, want fallback", got)
+	}
+	if got := p.Attribute("absent"); got != "" {
+		t.Fatalf("Attribute(absent) = %q, want empty", got)
 	}
 }
 
-// When only a namespaced attribute exists it is still returned by local name.
-func TestAttributeNamespacedFallback(t *testing.T) {
-	doc := `<root xmlns:o="http://other" o:href="only"/>`
-	p := xpp.NewXMLPullParser(bytes.NewReader([]byte(doc)), false, nil)
+func TestAttrsLiveMutation(t *testing.T) {
+	// gofeed rewrites attribute values in place to resolve relative URLs;
+	// the live-slice contract makes later reads see the modification.
+	p := newParser(`<root href="relative.html"/>`)
+	advanceTo(t, p, "root")
 
-	if _, err := p.NextTag(); err != nil {
-		t.Fatalf("next: %v", err)
+	attrs := p.Attrs()
+	for i := range attrs {
+		if attrs[i].Name.Local == "href" {
+			attrs[i].Value = "http://example.org/absolute.html"
+		}
 	}
-	if got := p.Attribute("href"); got != "only" {
-		t.Fatalf("Attribute(href) = %q, want %q", got, "only")
+	if got := p.Attribute("href"); got != "http://example.org/absolute.html" {
+		t.Fatalf("Attribute after mutation = %q, want the rewritten value", got)
+	}
+}
+
+func TestZeroValueParser(t *testing.T) {
+	var p xpp.Parser
+	if _, err := p.NextToken(); err == nil {
+		t.Fatal("zero-value parser should error, not panic")
+	}
+	if p.Err() == nil {
+		t.Fatal("zero-value parser error should be sticky")
+	}
+	if p.BaseURL() != nil || p.Attribute("x") != "" || p.Depth() != 0 {
+		t.Fatal("zero-value accessors should return zero values")
+	}
+}
+
+func TestInputOffset(t *testing.T) {
+	p := newParser(`<root><child/></root>`)
+	advanceTo(t, p, "root")
+	first := p.InputOffset()
+	advanceTo(t, p, "child")
+	if p.InputOffset() <= first {
+		t.Fatalf("InputOffset did not progress: %d then %d", first, p.InputOffset())
+	}
+}
+
+func TestIsWhitespace(t *testing.T) {
+	p := newParser("<root>  \n\t </root>")
+	advanceTo(t, p, "root")
+	if _, err := p.NextToken(); err != nil {
+		t.Fatal(err)
+	}
+	if p.Event() != xpp.Text || !p.IsWhitespace() {
+		t.Fatalf("event %v IsWhitespace %v, want whitespace Text", p.Event(), p.IsWhitespace())
 	}
 }


### PR DESCRIPTION
Implements the v2 design in #34. Also fixes #30, #32 and #33, whose remaining parts needed breaking changes. The module path becomes `github.com/mmcdole/goxpp/v2`; the `v1` branch (already pushed) keeps the old API and receives critical fixes.

## What changes

**Encapsulation.** `XMLPullParser` becomes `Parser` with no exported fields. Cursor state is read through methods (`Event()`, `Name()`, `Space()`, `Text()`, `Depth()`, `Attrs()`, plus `Attribute`, `IsWhitespace`, `InputOffset`, `Err`). The depth, namespace and base stacks can no longer be modified from outside; a desync of those stacks is what caused the #28 panic. One constructor remains: `New(*xml.Decoder)`. Strictness and charset conversion are set on the decoder, which already has fields for both.

**Errors.** Positional failures (`Expect`, `ExpectAll`, and the `NextTag`/`NextText`/`Skip`/`DecodeElement` preconditions) return `*ExpectError` with want/got fields and the input offset. Decoder errors pass through unchanged, so `errors.As` reaches `*xml.SyntaxError`. Advancement calls after `EndDocument` return `io.EOF` instead of succeeding forever (#33). The sticky error from a failed `DecodeElement` can be read with `Err()`.

**Namespaces (#32).** Tracked prefix to URI with case preserved, so two prefixes bound to the same URI no longer overwrite each other. `Namespaces()` returns a snapshot; `PrefixForURI()` does the reverse lookup, innermost scope first, most recent declaration first, skipping shadowed bindings.

**xml:base (#30).** The parser still tracks xml:base but no longer resolves document URLs against it. `BaseURL()` returns the in-scope base; nested bases resolve per RFC 3986. The trailing-slash directory heuristic and `XmlBaseResolveUrl` are deleted (gofeed had already forked that function rather than call it). An unparseable `xml:base` is treated as absent and the element inherits the parent base.

**Cursor semantics.** `Depth()` at an EndTag reports the same depth as the matching StartTag, per the Java model. The end tag's namespace scope and base stay visible until the next advancement, including for the end tag `DecodeElement` synthesizes, so callers no longer need to capture the base before decoding an element.

**Deleted:** the exported state fields, `urlStack`, `CharsetReader`, `NewXMLPullParser`, `NewXMLPullParserWithDecoder`, `XmlBaseResolveUrl`, `EventName`, the `EventType` method, `IgnorableWhitespace`.

**Unchanged on purpose** (reasons in #34): the cursor model itself, `Expect`'s case folding, `Attribute`'s exact matching with unprefixed preference, `Next`'s skip list. No options struct, no context parameter, no iterators (those are additive and can come in v2.1).

## Tests

Rewritten for the new API: 29 tests, 95.6% statement coverage. Coverage includes the #28 poison reproduction and every entry point failing after it, `io.EOF` after EndDocument, `*xml.SyntaxError` reachable through `errors.As`, duplicate and shadowed prefix lookups, RFC 3986 base resolution with a file-like base, base visibility on end tags and after `DecodeElement`, the in-place `Attrs` mutation gofeed relies on, and the zero-value `Parser` returning an error instead of panicking.

The gofeed migration lands as a separate PR once this merges and `v2.0.0` is tagged.